### PR TITLE
Version 0.2.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Version 0.2.0 2019-05-13
+
+- Code quality improvements thanks to phpstan and infection (mutation testing framework)
+- Remove `Capsule::append` method, `Capsule` is now immutable.
+- Throw `LogicException` when `DOMSigner` uses a document that does not have root element
+- `Capsule` now implements `Countable`
+
+
 ## Version 0.1.0 2019-04-09
 
 - First public version

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 0.2.1 2019-05-13
+
+- Release with new tag since v0.2.0 did not include this changes
+
 ## Version 0.2.0 2019-05-13
 
 - Code quality improvements thanks to phpstan and infection (mutation testing framework)

--- a/src/Capsule.php
+++ b/src/Capsule.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PhpCfdi\XmlCancelacion;
 
+use Countable;
 use DateTimeImmutable;
 
-class Capsule
+class Capsule implements Countable
 {
     /** @var string */
     private $rfc;

--- a/src/Capsule.php
+++ b/src/Capsule.php
@@ -15,7 +15,7 @@ class Capsule implements Countable
     /** @var DateTimeImmutable */
     private $date;
 
-    /** @var array */
+    /** @var array This is a B-Tree array, values are stored in keys */
     private $uuids;
 
     public function __construct(string $rfc, array $uuids = [], DateTimeImmutable $date = null)
@@ -23,7 +23,7 @@ class Capsule implements Countable
         $this->rfc = $rfc;
         $this->date = $date ?? new DateTimeImmutable('now');
         foreach ($uuids as $uuid) {
-            $this->append($uuid);
+            $this->uuids[strtoupper($uuid)] = true;
         }
     }
 
@@ -40,11 +40,6 @@ class Capsule implements Countable
     public function uuids(): array
     {
         return array_keys($this->uuids);
-    }
-
-    public function append(string $uuid): void
-    {
-        $this->uuids[strtoupper($uuid)] = true;
     }
 
     public function count(): int

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -141,10 +141,14 @@ class DOMSigner
 
     protected function createKeyValue(string $certificateFile): DOMElement
     {
-        $document = $this->document;
         $certificate = new Certificado($certificateFile);
-        $keyValue = $document->createElement('KeyValue');
+        return $this->createKeyValueFromCertificado($certificate);
+    }
 
+    protected function createKeyValueFromCertificado(Certificado $certificate): DOMElement
+    {
+        $document = $this->document;
+        $keyValue = $document->createElement('KeyValue');
         $pubKey = openssl_get_publickey($certificate->getPemContents());
         if (! is_resource($pubKey)) {
             throw new RuntimeException('Cannot read public key from certificate');

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -8,6 +8,7 @@ use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\PemPrivateKey\PemPrivateKey;
 use DOMDocument;
 use DOMElement;
+use LogicException;
 use RuntimeException;
 
 class DOMSigner
@@ -30,6 +31,14 @@ class DOMSigner
     public function __construct(DOMDocument $document)
     {
         $this->document = $document;
+    }
+
+    private function rootElement(DOMDocument $document): DOMElement
+    {
+        if (null === $document->documentElement) {
+            throw new LogicException('DOM Document does not have a root element');
+        }
+        return $document->documentElement;
     }
 
     public function getDigestSource(): string
@@ -63,7 +72,7 @@ class DOMSigner
 
         /** @var DOMElement $signature */
         $signature = $document->createElementNS('http://www.w3.org/2000/09/xmldsig#', 'Signature');
-        $document->documentElement->appendChild($signature);
+        $this->rootElement($document)->appendChild($signature);
 
         // append and realocate signedInfo to the node in document
         // SIGNEDINFO
@@ -109,7 +118,7 @@ class DOMSigner
         $docInfo->preserveWhiteSpace = false;
         $docInfo->formatOutput = false;
         $docInfo->loadXML($template);
-        $docinfoNode = $docInfo->documentElement;
+        $docinfoNode = $this->rootElement($docInfo);
 
         return $docinfoNode;
     }

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -159,18 +159,25 @@ class DOMSigner
     {
         $document = $this->document;
         $keyValue = $document->createElement('KeyValue');
-        $pubKey = openssl_get_publickey($certificate->getPemContents());
-        if (! is_resource($pubKey)) {
-            throw new RuntimeException('Cannot read public key from certificate');
-        }
-        $pubKeyData = openssl_pkey_get_details($pubKey);
+        $pubKeyData = $this->obtainPublicKeyValues($certificate->getPemContents());
         if (OPENSSL_KEYTYPE_RSA === $pubKeyData['type']) {
             $rsaKeyValue = $keyValue->appendChild($document->createElement('RSAKeyValue'));
             $rsaKeyValue->appendChild($document->createElement('Modulus', base64_encode($pubKeyData['rsa']['n'])));
             $rsaKeyValue->appendChild($document->createElement('Exponent', base64_encode($pubKeyData['rsa']['e'])));
         }
-        openssl_free_key($pubKey);
 
         return $keyValue;
+    }
+
+    protected function obtainPublicKeyValues(string $publicKeyContents): array
+    {
+        $pubKey = openssl_get_publickey($publicKeyContents);
+        if (! is_resource($pubKey)) {
+            throw new RuntimeException('Cannot read public key from certificate');
+        }
+        $pubKeyData = openssl_pkey_get_details($pubKey) ?: [];
+        openssl_free_key($pubKey);
+
+        return $pubKeyData;
     }
 }

--- a/tests/System/XmlSignedTest.php
+++ b/tests/System/XmlSignedTest.php
@@ -129,4 +129,10 @@ class XmlSignedTest extends TestCase
 
         $this->assertSame($this->signature, $signature);
     }
+
+    public function testWithPredefinedContent(): void
+    {
+        // file_put_contents($this->filePath('expected-signature.xml'), $this->signature);
+        $this->assertXmlStringEqualsXmlFile($this->filePath('expected-signature.xml'), $this->signature);
+    }
 }

--- a/tests/System/XmlSignedTest.php
+++ b/tests/System/XmlSignedTest.php
@@ -17,10 +17,16 @@ use RobRichards\XMLSecLibs\XMLSecurityDSig;
 class XmlSignedTest extends TestCase
 {
     /** @var DOMSigner */
-    private $creator;
+    private $domSigner;
 
     /** @var string */
-    private $xmlSigned;
+    private $signature;
+
+    /** @var Capsule */
+    private $capsule;
+
+    /** @var Credentials */
+    private $signObjects;
 
     public function setUp(): void
     {
@@ -43,8 +49,10 @@ class XmlSignedTest extends TestCase
         $signer = new DOMSigner($document);
         $signer->sign($signObjects);
 
-        $this->creator = $signer;
-        $this->xmlSigned = $document->saveXML();
+        $this->capsule = $capsule;
+        $this->signObjects = $signObjects;
+        $this->domSigner = $signer;
+        $this->signature = $document->saveXML();
     }
 
     public function testCreatedValues(): void
@@ -81,16 +89,16 @@ class XmlSignedTest extends TestCase
             . '3H05v6fDXvONgikCrC2sdzA0kM6qvrOpGfbgBd4au7eFFRjCA4oX9zcQUG9E4m+uVovj0ebp4EqDn9SC+Az3fi5AHom6adju8wx4u'
             . 'Jvi8isVg8ZP9KcuqEfXhIkyFutJrD61l00+XyZe4n5T1Aya+Ta0Q6NrA==';
 
-        $this->assertSame($expectedDigestSource, $this->creator->getDigestSource());
-        $this->assertSame($expectedDigestValue, $this->creator->getDigestValue());
-        $this->assertSame($expectedSignedInfo, $this->creator->getSignedInfoSource());
-        $this->assertSame($expectedSignedValue, $this->creator->getSignedInfoValue());
+        $this->assertSame($expectedDigestSource, $this->domSigner->getDigestSource());
+        $this->assertSame($expectedDigestValue, $this->domSigner->getDigestValue());
+        $this->assertSame($expectedSignedInfo, $this->domSigner->getSignedInfoSource());
+        $this->assertSame($expectedSignedValue, $this->domSigner->getSignedInfoValue());
     }
 
     public function testSignatureIsValidUsingXmlSecLib(): void
     {
         $document = new DOMDocument();
-        $document->loadXML($this->xmlSigned);
+        $document->loadXML($this->signature);
 
         $dSig = new XMLSecurityDSig();
         $signature = $dSig->locateSignature($document);
@@ -112,5 +120,13 @@ class XmlSignedTest extends TestCase
         $this->assertNotNull(XMLSecEnc::staticLocateKeyInfo($objKey, $signature), 'Cannot extract RSAKeyValue');
 
         $this->assertSame(1, $dSig->verify($objKey), 'Xml Signature verify fail');
+    }
+
+    public function testCapsuleSigner(): void
+    {
+        $signer = new CapsuleSigner();
+        $signature = $signer->sign($this->capsule, $this->signObjects);
+
+        $this->assertSame($this->signature, $signature);
     }
 }

--- a/tests/Unit/CapsuleSignerTest.php
+++ b/tests/Unit/CapsuleSignerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Tests\Unit;
+
+use PhpCfdi\XmlCancelacion\CapsuleSigner;
+use PhpCfdi\XmlCancelacion\Tests\TestCase;
+
+class CapsuleSignerTest extends TestCase
+{
+    public function testCreatedCapsuleSignerHasDefaultNameSpaces(): void
+    {
+        $signer = new CapsuleSigner();
+        $this->assertSame($signer->defaultExtraNamespaces(), $signer->extraNamespaces());
+    }
+
+    public function testDefaultNameSpacesExactContentAndOrder(): void
+    {
+        $signer = new CapsuleSigner();
+        $this->assertSame([
+            'xsd' => 'http://www.w3.org/2001/XMLSchema',
+            'xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+        ], $signer->defaultExtraNamespaces());
+    }
+}

--- a/tests/Unit/CapsuleTest.php
+++ b/tests/Unit/CapsuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Tests\Unit;
+
+use DateTimeImmutable;
+use PhpCfdi\XmlCancelacion\Capsule;
+use PhpCfdi\XmlCancelacion\Tests\TestCase;
+
+class CapsuleTest extends TestCase
+{
+    public function testConstructAndGetParameters(): void
+    {
+        $date = new DateTimeImmutable('2019-01-13 14:15:16');
+        $uuids = [
+            '12345678-1234-1234-1234-123456789001',
+            '12345678-1234-1234-1234-123456789002',
+        ];
+        $rfc = 'LAN7008173R5';
+        $capsule = new Capsule($rfc, $uuids, $date);
+        $this->assertSame($rfc, $capsule->rfc());
+        $this->assertSame($uuids, $capsule->uuids());
+        $this->assertSame($date, $capsule->date());
+    }
+
+    public function testConstructCapsuleWithoutDateGivesNow(): void
+    {
+        $uuids = [
+            '12345678-1234-1234-1234-123456789001',
+            '12345678-1234-1234-1234-123456789002',
+        ];
+        $rfc = 'LAN7008173R5';
+        $date = new DateTimeImmutable('now');
+        $capsule = new Capsule($rfc, $uuids, $date);
+        $this->assertSame(0, $date->getTimestamp() - $capsule->date()->getTimestamp());
+    }
+
+    public function testCount(): void
+    {
+        $date = new DateTimeImmutable('2019-01-13 14:15:16');
+        $uuids = [
+            '12345678-1234-1234-1234-123456789001',
+            '12345678-1234-1234-1234-123456789002',
+        ];
+        $rfc = 'LAN7008173R5';
+        $capsule = new Capsule($rfc, $uuids, $date);
+        $this->assertCount(2, $capsule);
+    }
+}

--- a/tests/Unit/DOMSignerTest.php
+++ b/tests/Unit/DOMSignerTest.php
@@ -7,6 +7,8 @@ namespace PhpCfdi\XmlCancelacion\Tests\Unit;
 use CfdiUtils\Certificado\Certificado;
 use DOMDocument;
 use DOMElement;
+use LogicException;
+use PhpCfdi\XmlCancelacion\Credentials;
 use PhpCfdi\XmlCancelacion\DOMSigner;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,5 +32,16 @@ class DOMSignerTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot read public key from certificate');
         $signer->exposeCreateKeyValueFromCertificado($certificate);
+    }
+
+    public function testThrowExceptionWhenPassingAnEmptyDomDocument(): void
+    {
+        /** @var Credentials&MockObject $credentials */
+        $credentials = $this->createMock(Credentials::class);
+        $signer = new DOMSigner(new DOMDocument());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Document does not have a root element');
+        $signer->sign($credentials);
     }
 }

--- a/tests/Unit/DOMSignerTest.php
+++ b/tests/Unit/DOMSignerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Tests\Unit;
+
+use CfdiUtils\Certificado\Certificado;
+use DOMDocument;
+use DOMElement;
+use PhpCfdi\XmlCancelacion\DOMSigner;
+use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+class DOMSignerTest extends TestCase
+{
+    public function testThrowExceptionWhenCannotGetPublicKeyFromCertificate(): void
+    {
+        /** @var Certificado&MockObject $certificate */
+        $certificate = $this->createMock(Certificado::class);
+        $certificate->method('getPemContents')->willReturn('BAD KEY');
+
+        $signer = new class(new DOMDocument()) extends DOMSigner {
+            public function exposeCreateKeyValueFromCertificado(Certificado $certificate): DOMElement
+            {
+                return $this->createKeyValueFromCertificado($certificate);
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot read public key from certificate');
+        $signer->exposeCreateKeyValueFromCertificado($certificate);
+    }
+}

--- a/tests/_files/expected-signature.xml
+++ b/tests/_files/expected-signature.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Cancelacion xmlns="http://cancelacfd.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             RfcEmisor="LAN7008173R5" Fecha="2019-04-05T16:29:17">
+    <Folios>
+        <UUID>E174F807-BEFA-4CF6-9B11-2A013B12F398</UUID>
+    </Folios>
+    <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <SignedInfo>
+            <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+            <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+            <Reference URI="">
+                <Transforms>
+                    <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                </Transforms>
+                <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                <DigestValue>j2x4spEq57R1mQD9lwXh2mmOyK8=</DigestValue>
+            </Reference>
+        </SignedInfo>
+        <SignatureValue>e0Cyi/rXOTFwW8ckNnwQEQ1oC6m73PDvExunnniCsZWQrDRV2SiaH9NoAhJhb5W9p5vJgB+PWu4J6uchG7EikDPbDPw19K3B7uZKTH7tZLffV/bZx6rozzreInvP+S1HhrnOqLPwebBm3Q3yRQk3pbaW2sHFPPuRPLqP+1h3Fegv4GEnwy+0G7LRg3H05v6fDXvONgikCrC2sdzA0kM6qvrOpGfbgBd4au7eFFRjCA4oX9zcQUG9E4m+uVovj0ebp4EqDn9SC+Az3fi5AHom6adju8wx4uJvi8isVg8ZP9KcuqEfXhIkyFutJrD61l00+XyZe4n5T1Aya+Ta0Q6NrA==</SignatureValue>
+        <KeyInfo>
+            <X509Data>
+                <X509IssuerSerial>
+                    <X509IssuerName>/CN=CINDEMEX SA DE CV/name=CINDEMEX SA DE CV/O=CINDEMEX SA DE CV/x500UniqueIdentifier=LAN7008173R5 / FUAB770117BXA/serialNumber= / FUAB770117MDFRNN09/OU=Prueba_CFDI</X509IssuerName>
+                    <X509SerialNumber>20001000000300022815</X509SerialNumber>
+                </X509IssuerSerial>
+                <X509Certificate>MIIFxTCCA62gAwIBAgIUMjAwMDEwMDAwMDAzMDAwMjI4MTUwDQYJKoZIhvcNAQELBQAwggFmMSAwHgYDVQQDDBdBLkMuIDIgZGUgcHJ1ZWJhcyg0MDk2KTEvMC0GA1UECgwmU2VydmljaW8gZGUgQWRtaW5pc3RyYWNpw7NuIFRyaWJ1dGFyaWExODA2BgNVBAsML0FkbWluaXN0cmFjacOzbiBkZSBTZWd1cmlkYWQgZGUgbGEgSW5mb3JtYWNpw7NuMSkwJwYJKoZIhvcNAQkBFhphc2lzbmV0QHBydWViYXMuc2F0LmdvYi5teDEmMCQGA1UECQwdQXYuIEhpZGFsZ28gNzcsIENvbC4gR3VlcnJlcm8xDjAMBgNVBBEMBTA2MzAwMQswCQYDVQQGEwJNWDEZMBcGA1UECAwQRGlzdHJpdG8gRmVkZXJhbDESMBAGA1UEBwwJQ295b2Fjw6FuMRUwEwYDVQQtEwxTQVQ5NzA3MDFOTjMxITAfBgkqhkiG9w0BCQIMElJlc3BvbnNhYmxlOiBBQ0RNQTAeFw0xNjEwMjUyMTUyMTFaFw0yMDEwMjUyMTUyMTFaMIGxMRowGAYDVQQDExFDSU5ERU1FWCBTQSBERSBDVjEaMBgGA1UEKRMRQ0lOREVNRVggU0EgREUgQ1YxGjAYBgNVBAoTEUNJTkRFTUVYIFNBIERFIENWMSUwIwYDVQQtExxMQU43MDA4MTczUjUgLyBGVUFCNzcwMTE3QlhBMR4wHAYDVQQFExUgLyBGVUFCNzcwMTE3TURGUk5OMDkxFDASBgNVBAsUC1BydWViYV9DRkRJMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgvvCiCFDFVaYX7xdVRhp/38ULWto/LKDSZy1yrXKpaqFXqERJWF78YHKf3N5GBoXgzwFPuDX+5kvY5wtYNxx/Owu2shNZqFFh6EKsysQMeP5rz6kE1gFYenaPEUP9zj+h0bL3xR5aqoTsqGF24mKBLoiaK44pXBzGzgsxZishVJVM6XbzNJVonEUNbI25DhgWAd86f2aU3BmOH2K1RZx41dtTT56UsszJls4tPFODr/caWuZEuUvLp1M3nj7Dyu88mhD2f+1fA/g7kzcU/1tcpFXF/rIy93APvkU72jwvkrnprzs+SnG81+/F16ahuGsb2EZ88dKHwqxEkwzhMyTbQIDAQABox0wGzAMBgNVHRMBAf8EAjAAMAsGA1UdDwQEAwIGwDANBgkqhkiG9w0BAQsFAAOCAgEAJ/xkL8I+fpilZP+9aO8n93+20XxVomLJjeSL+Ng2ErL2GgatpLuN5JknFBkZAhxVIgMaTS23zzk1RLtRaYvH83lBH5E+M+kEjFGp14Fne1iV2Pm3vL4jeLmzHgY1Kf5HmeVrrp4PU7WQg16VpyHaJ/eonPNiEBUjcyQ1iFfkzJmnSJvDGtfQK2TiEolDJApYv0OWdm4is9Bsfi9j6lI9/T6MNZ+/LM2L/t72Vau4r7m94JDEzaO3A0wHAtQ97fjBfBiO5M8AEISAV7eZidIl3iaJJHkQbBYiiW2gikreUZKPUX0HmlnIqqQcBJhWKRu6Nqk6aZBTETLLpGrvF9OArV1JSsbdw/ZH+P88RAt5em5/gjwwtFlNHyiKG5w+UFpaZOK3gZP0su0sa6dlPeQ9EL4JlFkGqQCgSQ+NOsXqaOavgoP5VLykLwuGnwIUnuhBTVeDbzpgrg9LuF5dYp/zs+Y9ScJqe5VMAagLSYTShNtN8luV7LvxF9pgWwZdcM7lUwqJmUddCiZqdngg3vzTactMToG16gZA4CWnMgbU4E+r541+FNMpgAZNvs2CiW/eApfaaQojsZEAHDsDv4L5n3M1CC7fYjE/d61aSng1LaO6T1mh+dEfPvLzp7zyzz+UgWMhi5Cs4pcXx1eic5r7uxPoBwcCTt3YI1jKVVnV7/w=</X509Certificate>
+            </X509Data>
+            <KeyValue>
+                <RSAKeyValue>
+                    <Modulus>gvvCiCFDFVaYX7xdVRhp/38ULWto/LKDSZy1yrXKpaqFXqERJWF78YHKf3N5GBoXgzwFPuDX+5kvY5wtYNxx/Owu2shNZqFFh6EKsysQMeP5rz6kE1gFYenaPEUP9zj+h0bL3xR5aqoTsqGF24mKBLoiaK44pXBzGzgsxZishVJVM6XbzNJVonEUNbI25DhgWAd86f2aU3BmOH2K1RZx41dtTT56UsszJls4tPFODr/caWuZEuUvLp1M3nj7Dyu88mhD2f+1fA/g7kzcU/1tcpFXF/rIy93APvkU72jwvkrnprzs+SnG81+/F16ahuGsb2EZ88dKHwqxEkwzhMyTbQ==</Modulus>
+                    <Exponent>AQAB</Exponent>
+                </RSAKeyValue>
+            </KeyValue>
+        </KeyInfo>
+    </Signature>
+</Cancelacion>


### PR DESCRIPTION
- Code quality improvements thanks to phpstan and infection (mutation testing framework)
- Remove `Capsule::append` method, `Capsule` is now immutable.
- Throw `LogicException` when `DOMSigner` uses a document that does not have root element
- `Capsule` now implements `Countable`