### PR TITLE
Version 0.3.0 (Fix ampersand on nodes with content)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.2",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "eclipxe/cfdiutils": "^2.10"
+        "eclipxe/cfdiutils": "^2.10.4"
     },
     "require-dev": {
         "robrichards/xmlseclibs": "^3.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,23 @@
 # CHANGELOG
 
+## Version 0.3.0 2019-06-27
+
+- Fix issue when calling `DOMDocument::createElement`/`DOMDocument::createElementNS` and content has an empersand `&`:
+    - `KeyInfo/X509Data/X509IssuerSerial/X509IssuerName`
+    - `Folios/UUID`
+    - Other uses on `createElement[NS]` are not important since they cannot have any ampersand.
+- Depends on `eclipxe/cfdiutils` version 2.10.4 to use `Xml::createElement` & `Xml::createElementNS`.
+- Move certificate extracting info from `DOMSigner::createKeyInfo` to `DOMSigner::sign`
+- Change signature of `DOMSigner::createKeyInfo(Certificado)` to
+  `DOMSigner::createKeyInfoElement(string $issuerName, string $serialNumber, string $pemContents)`, we can test it now.
+- Extract `DOMSigner::createKeyValueFromCertificado` to `DOMSigner::createKeyValueElement` to allow testing.
+- Remove protected method `DOMSigner::createKeyValueFromCertificado` in favor of `DOMSigner::createKeyValueFromPemContents`.
+
+
 ## Version 0.2.1 2019-05-13
 
 - Release with new tag since v0.2.0 did not include this changes
+
 
 ## Version 0.2.0 2019-05-13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Change signature of `DOMSigner::createKeyInfo(Certificado)` to
   `DOMSigner::createKeyInfoElement(string $issuerName, string $serialNumber, string $pemContents)`, we can test it now.
 - Extract `DOMSigner::createKeyValueFromCertificado` to `DOMSigner::createKeyValueElement` to allow testing.
-- Remove protected method `DOMSigner::createKeyValueFromCertificado` in favor of `DOMSigner::createKeyValueFromPemContents`.
+- Remove protected method `DOMSigner::createKeyValueFromCertificado` in favor of `DOMSigner::createKeyValueElement`.
 
 
 ## Version 0.2.1 2019-05-13

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,8 +2,3 @@
 
 - Poner el copyright correcto en cuanto esté el sitio de PhpCfdi
 - Dejar de usar CfdiUtils y usar phpcfdi/credentials cuando esté publicada y estable
-
-## Breaking changes for next major release
-
-- Remove _protected methods_ `DOMSigner::createKeyValue` and `DOMSigner::createKeyValueFromCertificado`.
-- Rename `DOMSigner::createKeyValueFromPemContents` to `DOMSigner::createKeyValue`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,3 +2,8 @@
 
 - Poner el copyright correcto en cuanto esté el sitio de PhpCfdi
 - Dejar de usar CfdiUtils y usar phpcfdi/credentials cuando esté publicada y estable
+
+## Breaking changes for next major release
+
+- Remove _protected methods_ `DOMSigner::createKeyValue` and `DOMSigner::createKeyValueFromCertificado`.
+- Rename `DOMSigner::createKeyValueFromPemContents` to `DOMSigner::createKeyValue`.

--- a/src/CapsuleSigner.php
+++ b/src/CapsuleSigner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\XmlCancelacion;
 
+use CfdiUtils\Utils\Xml;
 use DOMDocument;
 
 class CapsuleSigner
@@ -63,7 +64,7 @@ class CapsuleSigner
 
         // creación del UUID
         foreach ($capsule->uuids() as $uuid) {
-            $folios->appendChild($document->createElementNS($satns, 'UUID', $uuid));
+            $folios->appendChild(Xml::createElementNS($document, $satns, 'UUID', $uuid));
         }
 
         return $document;

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -157,29 +157,6 @@ class DOMSigner
         return $keyInfo;
     }
 
-    /**
-     * @param string $certificateFile
-     * @return DOMElement
-     * @deprecated 0.2.2:0.3.0 Use createKeyValueFromPemContents instead
-     * @codeCoverageIgnore
-     */
-    protected function createKeyValue(string $certificateFile): DOMElement
-    {
-        $certificate = new Certificado($certificateFile);
-        return $this->createKeyValueFromCertificado($certificate);
-    }
-
-    /**
-     * @param Certificado $certificate
-     * @return DOMElement
-     * @deprecated 0.2.2:0.3.0 Use createKeyValueFromPemContents instead
-     * @codeCoverageIgnore
-     */
-    protected function createKeyValueFromCertificado(Certificado $certificate): DOMElement
-    {
-        return $this->createKeyValueFromPemContents($certificate->getPemContents());
-    }
-
     protected function createKeyValueFromPemContents(string $pemContents): DOMElement
     {
         $document = $this->document;

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -157,9 +157,14 @@ class DOMSigner
 
     protected function createKeyValueFromCertificado(Certificado $certificate): DOMElement
     {
+        return $this->createKeyValueFromPemContents($certificate->getPemContents());
+    }
+
+    protected function createKeyValueFromPemContents(string $pemContents): DOMElement
+    {
         $document = $this->document;
         $keyValue = $document->createElement('KeyValue');
-        $pubKeyData = $this->obtainPublicKeyValues($certificate->getPemContents());
+        $pubKeyData = $this->obtainPublicKeyValues($pemContents);
         if (OPENSSL_KEYTYPE_RSA === $pubKeyData['type']) {
             $rsaKeyValue = $keyValue->appendChild($document->createElement('RSAKeyValue'));
             $rsaKeyValue->appendChild($document->createElement('Modulus', base64_encode($pubKeyData['rsa']['n'])));

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -157,12 +157,24 @@ class DOMSigner
         return $keyInfo;
     }
 
+    /**
+     * @param string $certificateFile
+     * @return DOMElement
+     * @deprecated 0.2.2:0.3.0 Use createKeyValueFromPemContents instead
+     * @codeCoverageIgnore
+     */
     protected function createKeyValue(string $certificateFile): DOMElement
     {
         $certificate = new Certificado($certificateFile);
         return $this->createKeyValueFromCertificado($certificate);
     }
 
+    /**
+     * @param Certificado $certificate
+     * @return DOMElement
+     * @deprecated 0.2.2:0.3.0 Use createKeyValueFromPemContents instead
+     * @codeCoverageIgnore
+     */
     protected function createKeyValueFromCertificado(Certificado $certificate): DOMElement
     {
         return $this->createKeyValueFromPemContents($certificate->getPemContents());

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -96,8 +96,12 @@ class DOMSigner
         );
 
         // KEYINFO
+        $certificate = new Certificado($signObjects->certificate());
+        $issuerName = $certificate->getCertificateName();
+        $serialNumber = $certificate->getSerialObject()->asAscii();
+        $pemContents = $certificate->getPemContents();
         $signature->appendChild(
-            $document->importNode($this->createKeyInfo($signObjects->certificate()), true)
+            $document->importNode($this->createKeyInfoElement($issuerName, $serialNumber, $pemContents), true)
         );
     }
 
@@ -124,16 +128,7 @@ class DOMSigner
         return $docinfoNode;
     }
 
-    protected function createKeyInfo(string $certificateFile): DOMElement
-    {
-        $certificate = new Certificado($certificateFile);
-        $issuerName = $certificate->getCertificateName();
-        $serialNumber = $certificate->getSerialObject()->asAscii();
-        $pemContents = $certificate->getPemContents();
-        return $this->createKeyInfoWithData($issuerName, $serialNumber, $pemContents);
-    }
-
-    protected function createKeyInfoWithData(string $issuerName, string $serialNumber, string $pemContents): DOMElement
+    protected function createKeyInfoElement(string $issuerName, string $serialNumber, string $pemContents): DOMElement
     {
         $document = $this->document;
         $keyInfo = $document->createElement('KeyInfo');
@@ -152,12 +147,12 @@ class DOMSigner
         $x509Data->appendChild($x509Certificate);
 
         $keyInfo->appendChild($x509Data);
+        $keyInfo->appendChild($this->createKeyValueElement($pemContents));
 
-        $keyInfo->appendChild($this->createKeyValueFromPemContents($pemContents));
         return $keyInfo;
     }
 
-    protected function createKeyValueFromPemContents(string $pemContents): DOMElement
+    protected function createKeyValueElement(string $pemContents): DOMElement
     {
         $document = $this->document;
         $keyValue = $document->createElement('KeyValue');

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\XmlCancelacion;
 
 use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\PemPrivateKey\PemPrivateKey;
+use CfdiUtils\Utils\Xml;
 use DOMDocument;
 use DOMElement;
 use LogicException;
@@ -139,15 +140,15 @@ class DOMSigner
         $x509Data = $document->createElement('X509Data');
         $x509IssuerSerial = $document->createElement('X509IssuerSerial');
         $x509IssuerSerial->appendChild(
-            $document->createElement('X509IssuerName', $issuerName)
+            Xml::createElement($document, 'X509IssuerName', $issuerName)
         );
         $x509IssuerSerial->appendChild(
-            $document->createElement('X509SerialNumber', $serialNumber)
+            Xml::createElement($document, 'X509SerialNumber', $serialNumber)
         );
         $x509Data->appendChild($x509IssuerSerial);
 
         $certificateContents = implode('', preg_grep('/^((?!-).)*$/', explode(PHP_EOL, $pemContents)));
-        $x509Certificate = $document->createElement('X509Certificate', $certificateContents);
+        $x509Certificate = Xml::createElement($document, 'X509Certificate', $certificateContents);
         $x509Data->appendChild($x509Certificate);
 
         $keyInfo->appendChild($x509Data);

--- a/tests/Unit/CapsuleSignerTest.php
+++ b/tests/Unit/CapsuleSignerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\XmlCancelacion\Tests\Unit;
 
+use DateTimeImmutable;
+use PhpCfdi\XmlCancelacion\Capsule;
 use PhpCfdi\XmlCancelacion\CapsuleSigner;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
 
@@ -22,5 +24,15 @@ class CapsuleSignerTest extends TestCase
             'xsd' => 'http://www.w3.org/2001/XMLSchema',
             'xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
         ], $signer->defaultExtraNamespaces());
+    }
+
+    public function testCreateDocumentWithAmpersandsOnUuids(): void
+    {
+        // even when UUID using ampersand is not correct, it does not have to break our library
+        $signer = new CapsuleSigner();
+        $badUuidWithAmpersand = 'E174F807-&&&&-4CF6-9B11-2A013B12F398';
+        $capsule = new Capsule('LAN7008173R5', [$badUuidWithAmpersand], new DateTimeImmutable('2019-04-05T16:29:17'));
+        $document = $signer->createDocument($capsule);
+        $this->assertStringContainsString(htmlspecialchars($badUuidWithAmpersand, ENT_XML1), $document->saveXML());
     }
 }

--- a/tests/Unit/DOMSignerTest.php
+++ b/tests/Unit/DOMSignerTest.php
@@ -39,4 +39,33 @@ class DOMSignerTest extends TestCase
         $this->expectExceptionMessage('Document does not have a root element');
         $signer->sign($credentials);
     }
+
+    public function testCreateKeyInfoWithIssuerNameWithAmpersand(): void
+    {
+        $issuerName = 'John & Co';
+        $document = new DOMDocument();
+        $signer = new class($document) extends DOMSigner {
+            public function exposeCreateKeyInfoWithData(string $issuerName): DOMElement
+            {
+                return $this->createKeyInfoWithData($issuerName, '', '');
+            }
+
+            protected function obtainPublicKeyValues(string $publicKeyContents): array
+            {
+                return [
+                    'type' => OPENSSL_KEYTYPE_RSA,
+                    'rsa' => ['n' => '1', 'e' => '2'],
+                ];
+            }
+        };
+
+        /** @var DOMElement $keyInfo */
+        $keyInfo = $signer->exposeCreateKeyInfoWithData($issuerName);
+
+        $this->assertXmlStringEqualsXmlString(
+            '<X509IssuerName>John &amp; Co</X509IssuerName>',
+            $document->saveXML($keyInfo->getElementsByTagName('X509IssuerName')[0]),
+            'Ampersand was not correctly parsed'
+        );
+    }
 }

--- a/tests/Unit/DOMSignerTest.php
+++ b/tests/Unit/DOMSignerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpCfdi\XmlCancelacion\Tests\Unit;
 
-use CfdiUtils\Certificado\Certificado;
 use DOMDocument;
 use DOMElement;
 use LogicException;
@@ -18,20 +17,16 @@ class DOMSignerTest extends TestCase
 {
     public function testThrowExceptionWhenCannotGetPublicKeyFromCertificate(): void
     {
-        /** @var Certificado&MockObject $certificate */
-        $certificate = $this->createMock(Certificado::class);
-        $certificate->method('getPemContents')->willReturn('BAD KEY');
-
         $signer = new class(new DOMDocument()) extends DOMSigner {
-            public function exposeCreateKeyValueFromCertificado(Certificado $certificate): DOMElement
+            public function exposeObtainPublicKeyValues(string $publicKey): array
             {
-                return $this->createKeyValueFromCertificado($certificate);
+                return $this->obtainPublicKeyValues($publicKey);
             }
         };
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot read public key from certificate');
-        $signer->exposeCreateKeyValueFromCertificado($certificate);
+        $signer->exposeObtainPublicKeyValues('BAD PUBLIC KEY');
     }
 
     public function testThrowExceptionWhenPassingAnEmptyDomDocument(): void

--- a/tests/Unit/DOMSignerTest.php
+++ b/tests/Unit/DOMSignerTest.php
@@ -44,9 +44,9 @@ class DOMSignerTest extends TestCase
     {
         $document = new DOMDocument();
         $signer = new class($document) extends DOMSigner {
-            public function exposeCreateKeyInfoWithData(string $issuerName, string $serialNumber, string $pemContents): DOMElement
+            public function exposeCreateKeyInfoElement(string $issuerName, string $serialNumber, string $pemContents): DOMElement
             {
-                return $this->createKeyInfoWithData($issuerName, $serialNumber, $pemContents);
+                return $this->createKeyInfoElement($issuerName, $serialNumber, $pemContents);
             }
 
             protected function obtainPublicKeyValues(string $publicKeyContents): array
@@ -62,7 +62,7 @@ class DOMSignerTest extends TestCase
         $serialNumber = '&0001';
         $pemContents = '&';
         /** @var DOMElement $keyInfo */
-        $keyInfo = $signer->exposeCreateKeyInfoWithData($issuerName, $serialNumber, $pemContents);
+        $keyInfo = $signer->exposeCreateKeyInfoElement($issuerName, $serialNumber, $pemContents);
 
         $this->assertXmlStringEqualsXmlString(
             sprintf('<X509IssuerName>%s</X509IssuerName>', htmlspecialchars($issuerName, ENT_XML1)),


### PR DESCRIPTION
- Fix issue when calling `DOMDocument::createElement`/`DOMDocument::createElementNS` and content has an empersand `&`:
    - `KeyInfo/X509Data/X509IssuerSerial/X509IssuerName`
    - `Folios/UUID`
    - Other uses on `createElement[NS]` are not important since they cannot have any ampersand.
- Depends on `eclipxe/cfdiutils` version 2.10.4 to use `Xml::createElement` & `Xml::createElementNS`.
- Move certificate extracting info from `DOMSigner::createKeyInfo` to `DOMSigner::sign`
- Change signature of `DOMSigner::createKeyInfo(Certificado)` to
  `DOMSigner::createKeyInfoElement(string $issuerName, string $serialNumber, string $pemContents)`, we can test it now.
- Extract `DOMSigner::createKeyValueFromCertificado` to `DOMSigner::createKeyValueElement` to allow testing.
- Remove protected method `DOMSigner::createKeyValueFromCertificado` in favor of `DOMSigner::createKeyValueElement`.
