### PR TITLE
Move dependence from eclipxe/cfdiutils to phpcfdi/credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,5 @@ vendor/bin/parallel-lint src/ tests/
 vendor/bin/phpcs -sp src/ tests/
 vendor/bin/php-cs-fixer fix -v --dry-run
 vendor/bin/phpunit --coverage-text
+vendor/bin/phpstan.phar analyse --no-progress --level max src/ tests/
 ```

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [license]: https://github.com/phpcfdi/xml-cancelacion/blob/master/LICENSE
 [build]: https://travis-ci.org/phpcfdi/xml-cancelacion?branch=master
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/xml-cancelacion/
-[coverage]: https://scrutinizer-ci.com/g/phpcfdi/xml-cancelacion/code-structure/master/code-coverage
+[coverage]: https://scrutinizer-ci.com/g/phpcfdi/xml-cancelacion/code-structure/master/code-coverage/src/
 [downloads]: https://packagist.org/packages/phpcfdi/xml-cancelacion
 
-[badge-source]: http://img.shields.io/badge/source-phpcfdi/xml--cancelacion-blue.svg?style=flat-square
-[badge-release]: https://img.shields.io/github/release/phpcfdi/xml-cancelacion.svg?style=flat-square
-[badge-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[badge-build]: https://img.shields.io/travis/phpcfdi/xml-cancelacion/master.svg?style=flat-square
-[badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/xml-cancelacion/master.svg?style=flat-square
-[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/xml-cancelacion/master.svg?style=flat-square
-[badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/xml-cancelacion.svg?style=flat-square
+[badge-source]: http://img.shields.io/badge/source-phpcfdi/xml--cancelacion-blue?style=flat-square
+[badge-release]: https://img.shields.io/github/release/phpcfdi/xml-cancelacion?style=flat-square
+[badge-license]: https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square
+[badge-build]: https://img.shields.io/travis/phpcfdi/xml-cancelacion/master?style=flat-square
+[badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/xml-cancelacion/master?style=flat-square
+[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/xml-cancelacion/master?style=flat-square
+[badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/xml-cancelacion?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.2",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "phpcfdi/credentials": "dev-master"
+        "phpcfdi/credentials": "^1.0"
     },
     "require-dev": {
         "robrichards/xmlseclibs": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.2",
         "ext-dom": "*",
         "ext-openssl": "*",
-        "eclipxe/cfdiutils": "^2.10.4"
+        "phpcfdi/credentials": "dev-master"
     },
     "require-dev": {
         "robrichards/xmlseclibs": "^3.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+
+## Version 0.4.0 2019-08-13
+
+- Drop dependence from `eclipxe/cfdiutils` to `phpcfdi/credentials`
+- `PhpCfdi\XmlCancelacion\Credentials` changed from DTO to encapsulate certificate & private key logic:
+    - uses internally `PhpCfdi\Credentials\Credential`
+    - offers methods to extract any data or execute any action from certificate or private key
+- Minor improvements in documentation
+
+
 ## Version 0.3.0 2019-06-27
 
 - Fix issue when calling `DOMDocument::createElement`/`DOMDocument::createElementNS` and content has an empersand `&`:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
-    <rule ref="PSR2" />
+    <rule ref="PSR2"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/src/CapsuleSigner.php
+++ b/src/CapsuleSigner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpCfdi\XmlCancelacion;
 
-use CfdiUtils\Utils\Xml;
 use DOMDocument;
 
 class CapsuleSigner
@@ -72,7 +71,7 @@ class CapsuleSigner
 
         // creación del UUID
         foreach ($capsule->uuids() as $uuid) {
-            $folios->appendChild(Xml::createElementNS($document, $satns, 'UUID', $uuid));
+            $folios->appendChild($document->createElementNS($satns, 'UUID', htmlspecialchars($uuid, ENT_XML1)));
         }
 
         return $document;

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace PhpCfdi\XmlCancelacion;
 
+use PhpCfdi\Credentials\Credential;
+use RuntimeException;
+use Throwable;
+
 class Credentials
 {
     /** @var string */
@@ -14,6 +18,9 @@ class Credentials
 
     /** @var string */
     private $passPhrase;
+
+    /** @var Credential|null */
+    private $csd;
 
     public function __construct(string $certificate, string $privateKey, string $passPhrase)
     {
@@ -35,5 +42,51 @@ class Credentials
     public function passPhrase(): string
     {
         return $this->passPhrase;
+    }
+
+    public function sign(string $data, int $algorithm = OPENSSL_ALGO_SHA256): string
+    {
+        return $this->getCsd()->sign($data, $algorithm);
+    }
+
+    public function certificateIssuerName(): string
+    {
+        return $this->getCsd()->certificate()->name();
+    }
+
+    public function serialNumber(): string
+    {
+        return $this->getCsd()->certificate()->serialNumber()->bytes();
+    }
+
+    public function certificateAsPEM(): string
+    {
+        return $this->getCsd()->certificate()->pem();
+    }
+
+    public function publicKeyData(): array
+    {
+        return $this->getCsd()->certificate()->publicKey()->parsed();
+    }
+
+    protected function makePhpCfdiCredential(): Credential
+    {
+        return Credential::openFiles($this->certificate(), $this->privateKey(), $this->passPhrase());
+    }
+
+    protected function getCsd(): Credential
+    {
+        if (null === $this->csd) {
+            try {
+                $credential = $this->makePhpCfdiCredential();
+                if (! $credential->isCsd()) {
+                    throw new RuntimeException('The certificate is not a CSD from SAT');
+                }
+                $this->csd = $credential;
+            } catch (Throwable $error) {
+                throw new RuntimeException('Cannot load certificate and private key', 0, $error);
+            }
+        }
+        return $this->csd;
     }
 }

--- a/src/DOMSigner.php
+++ b/src/DOMSigner.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\XmlCancelacion;
 
 use CfdiUtils\Certificado\Certificado;
 use CfdiUtils\PemPrivateKey\PemPrivateKey;
-use CfdiUtils\Utils\Xml;
 use DOMDocument;
 use DOMElement;
 use LogicException;
@@ -135,16 +134,17 @@ class DOMSigner
         $x509Data = $document->createElement('X509Data');
         $x509IssuerSerial = $document->createElement('X509IssuerSerial');
         $x509IssuerSerial->appendChild(
-            Xml::createElement($document, 'X509IssuerName', $issuerName)
+            $document->createElement('X509IssuerName', htmlspecialchars($issuerName, ENT_XML1))
         );
         $x509IssuerSerial->appendChild(
-            Xml::createElement($document, 'X509SerialNumber', $serialNumber)
+            $document->createElement('X509SerialNumber', htmlspecialchars($serialNumber, ENT_XML1))
         );
         $x509Data->appendChild($x509IssuerSerial);
 
         $certificateContents = implode('', preg_grep('/^((?!-).)*$/', explode(PHP_EOL, $pemContents)));
-        $x509Certificate = Xml::createElement($document, 'X509Certificate', $certificateContents);
-        $x509Data->appendChild($x509Certificate);
+        $x509Data->appendChild(
+            $document->createElement('X509Certificate', htmlspecialchars($certificateContents, ENT_XML1))
+        );
 
         $keyInfo->appendChild($x509Data);
         $keyInfo->appendChild($this->createKeyValueElement($pemContents));

--- a/tests/Unit/CredentialsTest.php
+++ b/tests/Unit/CredentialsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Tests\Unit;
+
+use PhpCfdi\Credentials\Credential as PhpCfdiCredential;
+use PhpCfdi\XmlCancelacion\Credentials;
+use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+class CredentialsTest extends TestCase
+{
+    public function testCreateCsdWithInvalidPassword(): void
+    {
+        $cerContent = $this->filePath('LAN7008173R5.cer.pem');
+        $keyContent = $this->filePath('LAN7008173R5.key.pem');
+        $passPhrase = 'this is sparta!';
+
+        $credential = new Credentials($cerContent, $keyContent, $passPhrase);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot load certificate and private key');
+        $credential->certificateIssuerName(); // something that require csd creation
+    }
+
+    public function testCreateCsdWithInvalidCredential(): void
+    {
+        $cerContent = $this->filePath('LAN7008173R5.cer.pem');
+        $keyContent = $this->filePath('LAN7008173R5.key.pem');
+        $passPhrase = trim($this->fileContents('LAN7008173R5.password'));
+
+        $phpCfdiCredential = $this->getMockBuilder(PhpCfdiCredential::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $phpCfdiCredential->method('isCsd')->willReturn(false);
+
+        /** @var Credentials&MockObject $credential */
+        $credential = $this->getMockBuilder(Credentials::class)
+            ->setConstructorArgs([$cerContent, $keyContent, $passPhrase])
+            ->onlyMethods(['makePhpCfdiCredential'])
+            ->getMock();
+        $credential->expects($this->once())->method('makePhpCfdiCredential')->willReturn($phpCfdiCredential);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot load certificate and private key');
+        $credential->certificateIssuerName(); // something that require csd creation
+    }
+}


### PR DESCRIPTION
- Drop dependence from `eclipxe/cfdiutils` to `phpcfdi/credentials`
- `PhpCfdi\XmlCancelacion\Credentials` changed from DTO to encapsulate certificate & private key logic:
    - uses internally `PhpCfdi\Credentials\Credential`
    - offers methods to extract any data or execute any action from certificate or private key
- Minor improvements in documentation
