### PR TITLE
Include a helper object `XmlCancelacionHelper` that simplify working with this library

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,10 +5,7 @@ filter:
 
 build:
   nodes:
-    php73:
-      environment:
-        php:
-          version: "7.3"
+    build:
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ Las otras dos desventajas están en la forma en que escribe los valores de `X509
 Que aunque creo que no son muy relevantes para generar una firma correcta, sí podrían ser importantes,
 y motivo de rechazo -o pretexto- en el servicio de cancelación del SAT.
 
-Al momento existe una dependencia fuerte a `eclipxe/cfdiutils`, sin embargo, esta dependencia va a desaparecer porque
-se va a crear un nuevo paquete bajo la organización `PhpCfdi` para certificados, llaves privadas y llaves públicas.
+A partir de 2019-08-13 con la versión `0.4.0` se eliminó la dependencia a `eclipxe/cfdiutils` y se cambió a la
+librería [`phpcfdi/credentials`](https://github.com/phpcfdi/xml-cancelacion), con esta nueva dependencia se trabaja
+mucho mejor con los certificados y llaves privadas.
 
 
 ## Compatilibilidad

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 
 [badge-source]: http://img.shields.io/badge/source-phpcfdi/xml--cancelacion-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/xml-cancelacion?style=flat-square
-[badge-license]: https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square
+[badge-license]: https://img.shields.io/github/license/phpcfdi/xml-cancelacion?style=flat-square
 [badge-build]: https://img.shields.io/travis/phpcfdi/xml-cancelacion/master?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/xml-cancelacion/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/xml-cancelacion/master?style=flat-square

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ composer require phpcfdi/xml-cancelacion
 
 ## Ejemplo básico de uso
 
+### Con el objeto de ayuda
+
+```php
+<?php
+
+use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
+
+$solicitudCancelacion = (new XmlCancelacionHelper())
+    ->setNewCredentials('certificado.cer', 'llaveprivada.key', 'contraseña')
+    ->make('11111111-2222-3333-4444-000000000001');
+
+```
+
+### Con un uso detallado
+
 ```php
 <?php
 use PhpCfdi\XmlCancelacion\Capsule;
@@ -96,7 +111,25 @@ La salida esperada es algo como lo siguiente (sin los espacios en blanco que agr
 ```
 
 
-## Objetos principales
+## Objeto de ayuda
+
+**`XmlCancelacionHelper``** te permite usar la librería rápidamente.
+
+Requiere de un objeto `Credentials` que puede ser insertado en la construcción,
+puede ser insertado con el método `setCredentials` o por `setNewCredentials`.
+La diferencia entre estos dos métodos es que el primero recibe un objeto, y el segundo
+recibe los parámetros de certificado, llave privada y contraseña.
+
+Para crear la solicitud firmada se puede hacer con los métodos `make` para un sólo UUID
+o `makeUuids` para varios UUID. Como primer parámetro reciben qué UUID será cancelado y
+como segundo parámetro (opcional) un `DateTimeImmutable` o `null`, en ese caso tomará
+la fecha y hora del sistema.
+
+Con este objeto no se especifica el RFC, cuando se fabrica la solicitud firmada se obtiene
+el RFC directamente de las propiedades del certificado.
+
+
+## Objetos de trabajo
 
 **`Capsule`** es un contenedor de información que contiene RFC, Fecha y UUID.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ La salida esperada es algo como lo siguiente (sin los espacios en blanco que agr
 
 ## Objeto de ayuda
 
-**`XmlCancelacionHelper``** te permite usar la librería rápidamente.
+**`XmlCancelacionHelper`** te permite usar la librería rápidamente.
 
 Requiere de un objeto `Credentials` que puede ser insertado en la construcción,
 puede ser insertado con el método `setCredentials` o por `setNewCredentials`.
@@ -125,8 +125,8 @@ o `makeUuids` para varios UUID. Como primer parámetro reciben qué UUID será c
 como segundo parámetro (opcional) un `DateTimeImmutable` o `null`, en ese caso tomará
 la fecha y hora del sistema.
 
-Con este objeto no se especifica el RFC, cuando se fabrica la solicitud firmada se obtiene
-el RFC directamente de las propiedades del certificado.
+Con esta herramienta de ayuda no se especifica el RFC, cuando se fabrica la solicitud firmada
+se obtiene el RFC directamente de las propiedades del certificado.
 
 
 ## Objetos de trabajo

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 0.4.2 2019-09-05
+
+- Include a helper object `XmlCancelacionHelper` that simplify working with this library,
+  see [README](https://github.com/phpcfdi/xml-cancelacion/blob/master/README.md) for usage.
+- Other minimal changes on documentation.
+
 
 ## Version 0.4.1 2019-08-13
 

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -89,4 +89,9 @@ class Credentials
         }
         return $this->csd;
     }
+
+    public function rfc(): string
+    {
+        return $this->getCsd()->rfc();
+    }
 }

--- a/src/XmlCancelacionHelper.php
+++ b/src/XmlCancelacionHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion;
+
+use DateTimeImmutable;
+
+class XmlCancelacionHelper
+{
+    /** @var Credentials|null */
+    private $credentials;
+
+    /**
+     * XmlCancelacionHelper constructor.
+     * @param Credentials|null $credentials
+     */
+    public function __construct(?Credentials $credentials = null)
+    {
+        $this->credentials = $credentials;
+    }
+
+    public function hasCredentials(): bool
+    {
+        return (null !== $this->credentials);
+    }
+
+    public function getCredentials(): Credentials
+    {
+        if (null === $this->credentials) {
+            throw new \LogicException('The object has no credentials');
+        }
+        return $this->credentials;
+    }
+
+    public function setCredentials(Credentials $credentials): self
+    {
+        $this->credentials = $credentials;
+        return $this;
+    }
+
+    public function setNewCredentials(string $certificate, string $privateKey, string $passPhrase): self
+    {
+        $credentials = new Credentials($certificate, $privateKey, $passPhrase);
+        return $this->setCredentials($credentials);
+    }
+
+    public function make(string $uuid, ? DateTimeImmutable $dateTime = null): string
+    {
+        return $this->makeUuids([$uuid], $dateTime);
+    }
+
+    public function makeUuids(array $uuids, ? DateTimeImmutable $dateTime = null): string
+    {
+        $dateTime = $dateTime ?? new DateTimeImmutable();
+        $credentials = $this->getCredentials();
+        $capsule = $this->createCapsule($credentials->rfc(), $uuids, $dateTime);
+        $signer = $this->createCapsuleSigner();
+        return $signer->sign($capsule, $credentials);
+    }
+
+    protected function createCapsule(string $rfc, array $uuids, DateTimeImmutable $dateTime): Capsule
+    {
+        return new Capsule($rfc, $uuids, $dateTime);
+    }
+
+    protected function createCapsuleSigner(): CapsuleSigner
+    {
+        return new CapsuleSigner();
+    }
+}

--- a/tests/Unit/CredentialsTest.php
+++ b/tests/Unit/CredentialsTest.php
@@ -12,6 +12,31 @@ use RuntimeException;
 
 class CredentialsTest extends TestCase
 {
+    public function testValidCredentialsProperties(): void
+    {
+        $cerFile = $this->filePath('LAN7008173R5.cer.pem');
+        $keyFile = $this->filePath('LAN7008173R5.key.pem');
+        $passPhrase = trim($this->fileContents('LAN7008173R5.password'));
+        $signature = 'Dw9fnvXKvDCy+oFqGNWG2ho1wcLaY4I9ddh5e+WqB5rfHbZEMyspuqQzYux2OL0U+g7arlx/w5imdQxjBlvrKgulX7'
+            . 'K7HcHel60knsneDebEJNA0tyeTnJJn2e6DPd5GtxrLEHsjKtTGxl4p8QynX0x5uJoog09ZgIQ3adSq3cciH3FOfupiq9NbtMQ'
+            . 'k9Da8ezI+pc5L0uu+mC9+RAR+r3agRkigGhGIeatS2QrA/B4FjZW2kzivz7J3zWEMm+JJMdYKzBoc7Us3aOS+kzuaz4T8+/yf'
+            . 'IZy2qa9QEnxpOvk0Prh43LaObh9MKbu3uOnWaO3yMSuKE6DHZqmWtcO57A==';
+
+        $credentials = new Credentials($cerFile, $keyFile, $passPhrase);
+
+        $this->assertSame($cerFile, $credentials->certificate());
+        $this->assertSame($keyFile, $credentials->privateKey());
+        $this->assertSame($passPhrase, $credentials->passPhrase());
+
+        $this->assertSame('LAN7008173R5', $credentials->rfc());
+        $this->assertSame('20001000000300022815', $credentials->serialNumber());
+        $this->assertStringStartsWith(
+            'CN=A.C. 2 de pruebas(4096),O=Servicio de Administración Tributaria',
+            $credentials->certificateIssuerName()
+        );
+        $this->assertSame($signature, base64_encode($credentials->sign('foo')));
+    }
+
     public function testCreateCsdWithInvalidPassword(): void
     {
         $cerContent = $this->filePath('LAN7008173R5.cer.pem');

--- a/tests/Unit/XmlCancelacionHelperTest.php
+++ b/tests/Unit/XmlCancelacionHelperTest.php
@@ -12,10 +12,8 @@ use PhpCfdi\XmlCancelacion\Tests\TestCase;
 use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/**
- * @covers \PhpCfdi\XmlCancelacion\XmlCancelacionHelper
- */
-class XmlCancelacionBuilderTest extends TestCase
+/** @covers \PhpCfdi\XmlCancelacion\XmlCancelacionHelper */
+class XmlCancelacionHelperTest extends TestCase
 {
     /** @return Credentials&MockObject */
     private function createFakeCredentials(): Credentials

--- a/tests/Unit/XmlCancelacionHelperTest.php
+++ b/tests/Unit/XmlCancelacionHelperTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Tests\Unit;
+
+use DateTimeImmutable;
+use LogicException;
+use PhpCfdi\XmlCancelacion\Capsule;
+use PhpCfdi\XmlCancelacion\Credentials;
+use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \PhpCfdi\XmlCancelacion\XmlCancelacionHelper
+ */
+class XmlCancelacionBuilderTest extends TestCase
+{
+    /** @return Credentials&MockObject */
+    private function createFakeCredentials(): Credentials
+    {
+        /** @var Credentials&MockObject $credentials */
+        $credentials = $this->createMock(Credentials::class);
+        return $credentials;
+    }
+
+    private function createRealCredentials(): Credentials
+    {
+        $cerFile = $this->filePath('LAN7008173R5.cer.pem');
+        $keyFile = $this->filePath('LAN7008173R5.key.pem');
+        $passPhrase = trim($this->fileContents('LAN7008173R5.password'));
+        return new Credentials($cerFile, $keyFile, $passPhrase);
+    }
+
+    public function testCredentialChanges(): void
+    {
+        $fakeCredentials = $this->createFakeCredentials();
+
+        $helper = new XmlCancelacionHelper();
+        $this->assertFalse($helper->hasCredentials());
+
+        $this->assertSame($helper, $helper->setCredentials($fakeCredentials));
+        $this->assertTrue($helper->hasCredentials());
+
+        $cerFile = $this->filePath('LAN7008173R5.cer.pem');
+        $keyFile = $this->filePath('LAN7008173R5.key.pem');
+        $passPhrase = trim($this->fileContents('LAN7008173R5.password'));
+        $this->assertSame($helper, $helper->setNewCredentials($cerFile, $keyFile, $passPhrase));
+        $this->assertTrue($helper->hasCredentials());
+        $this->assertSame('LAN7008173R5', $helper->getCredentials()->rfc());
+    }
+
+    public function testMakeCallsMakeUuids(): void
+    {
+        $uuid = '11111111-2222-3333-4444-000000000001';
+        $predefinedReturn = 'signed-xml';
+
+        /** @var XmlCancelacionHelper&MockObject $helper */
+        $helper = $this->getMockBuilder(XmlCancelacionHelper::class)
+            ->onlyMethods(['makeUuids'])
+            ->getMock();
+        $helper->expects($this->once())
+            ->method('makeUuids')
+            ->with($this->equalTo([$uuid]), $this->isNull())
+            ->willReturn($predefinedReturn);
+
+        $this->assertSame($predefinedReturn, $helper->make($uuid));
+    }
+
+    public function testMakeUuids(): void
+    {
+        $credentials = $this->createRealCredentials();
+        $rfc = $credentials->rfc();
+        $uuids = ['11111111-2222-3333-4444-000000000001', '11111111-2222-3333-4444-000000000002'];
+        $helper = new class() extends XmlCancelacionHelper {
+            /** @var Capsule */
+            private $capsule;
+
+            protected function createCapsule(string $rfc, array $uuids, DateTimeImmutable $dateTime): Capsule
+            {
+                $this->capsule = parent::createCapsule($rfc, $uuids, $dateTime);
+                return $this->capsule;
+            }
+
+            public function getCreatedCapsule(): Capsule
+            {
+                return $this->capsule;
+            }
+        };
+
+        $now = new DateTimeImmutable();
+        $result = $helper->setCredentials($credentials)->makeUuids($uuids);
+        $this->assertStringContainsString('<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">', $result);
+
+        /** @var Capsule $spyCapsule */
+        $spyCapsule = $helper->getCreatedCapsule();
+        $spyDate = $spyCapsule->date();
+        $this->assertSame($rfc, $spyCapsule->rfc());
+        $this->assertSame($uuids, $spyCapsule->uuids());
+        $this->assertTrue($spyDate > $now->modify('-1 second') && $spyDate < $now->modify('+1 second'));
+    }
+
+    public function testGetCredentialsWithoutSettingBefore(): void
+    {
+        $helper = new XmlCancelacionHelper();
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The object has no credentials');
+        $helper->getCredentials();
+    }
+
+    public function testCanConstructWithCredentials(): void
+    {
+        $credentials = $this->createFakeCredentials();
+        $helper = new XmlCancelacionHelper($credentials);
+        $this->assertSame($credentials, $helper->getCredentials());
+    }
+}


### PR DESCRIPTION
- Create helper object, test and documentation on README
- Creates a method to read to the outside the RFC from a certificate
- Fixes old README documentation