### PR TITLE
Fix travis build, update to phpstan ^0.12.54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpunit/phpunit": "^8.3.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.12"
+        "phpstan/phpstan": "^0.12.54"
     },
     "suggest": {
         "robrichards/xmlseclibs": "Create document signatures (partially) using xmlseclibs"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## UNRELEASED 2020-11-12
+
+- Fix Travis-CI build: `phpstan: ^0.12.54` detects issues on unit tests control flow.
+
 ## Version 1.1.1 2020-08-28
 
 - Refactor `CreateKeyInfoElementTraitTest` explaining what it is for.

--- a/tests/System/SignerImplementations/SignerImplementationTestCase.php
+++ b/tests/System/SignerImplementations/SignerImplementationTestCase.php
@@ -121,7 +121,6 @@ abstract class SignerImplementationTestCase extends TestCase
         $objKey = $dSig->locateKey();
         if (null === $objKey) {
             $this->fail('Cannot locate XMLSecurityKey object');
-            return;
         }
 
         // must call, otherwise verify will not have the public key to check signature


### PR DESCRIPTION
- Fix Travis-CI build: `phpstan: ^0.12.54` detects issues on unit tests control flow.