### PR TITLE
Preparación de versión 1.1.2 (revisión 2021-09-03)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,18 +2,20 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
-/vendor              export-ignore
-/composer.lock       export-ignore
+/tools/                     export-ignore
+/vendor/                    export-ignore
+/composer.lock              export-ignore
 
 # Do not put this files on a distribution package
 /.github/                   export-ignore
-/docs/               export-ignore
-/tests/              export-ignore
-/.gitattributes      export-ignore
-/.gitignore          export-ignore
-/.php_cs.dist        export-ignore
-/.scrutinizer.yml    export-ignore
-/.travis.yml         export-ignore
-/phpcs.xml.dist      export-ignore
-/phpstan.neon.dist   export-ignore
-/phpunit.xml.dist    export-ignore
+/build/                     export-ignore
+/tests/                     export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.php-cs-fixer.dist.php     export-ignore
+/.scrutinizer.yml           export-ignore
+/infection.json.dist        export-ignore
+/phpcs.xml.dist             export-ignore
+/phpstan.xml.dist           export-ignore
+/phpunit.xml.dist           export-ignore
+/psalm.xml.dist             export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,67 @@ on:
 
 jobs:
 
+  ci: # this job runs all the development tools and upload code coverage to scrutinizer
+
+    name: PHP 8.0 (full)
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # see https://github.com/marketplace/actions/setup-php-action
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: dom, openssl
+          coverage: xdebug
+          tools: composer:v2, phpcs, php-cs-fixer, phpstan, psalm, infection, cs2pr
+        env:
+          fail-fast: true
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+
+      - name: Code style (phpcs)
+        run: phpcs -q --report=checkstyle | cs2pr
+
+      - name: Code style (php-cs-fixer)
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+
+      - name: Tests (phpunit with code coverage)
+        run: vendor/bin/phpunit --testdox --verbose --coverage-clover=build/coverage-clover.xml --coverage-xml=build/coverage --log-junit=build/coverage/junit.xml
+
+      - name: Code analysis (phpstan)
+        run: phpstan analyse --no-progress --verbose
+
+      - name: Code analysis (psalm)
+        run: psalm --no-progress --output-format=github
+
+      - name: Mutation testing analysis
+        run: infection --skip-initial-tests --coverage=build/coverage --no-progress --no-interaction --logger-github
+        continue-on-error: true
+
+      # see https://github.com/marketplace/actions/action-scrutinizer
+      - name: Upload code coverage to scrutinizer
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover build/coverage-clover.xml"
+        continue-on-error: true
+
   build: # this job runs tests on all php supported versions
 
     name: PHP ${{ matrix.php-versions }} (tests)
@@ -16,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4']
 
     steps:
 
@@ -28,7 +89,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: soap
+          extensions: dom, openssl
           coverage: none
           tools: composer:v2, cs2pr
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # do not include this files on git
-/vendor
+/tools/
+/vendor/
 /composer.lock

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="php-cs-fixer" version="^3.1.0" installed="3.1.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.6.0" installed="3.6.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.0" installed="3.6.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^0.12.98" installed="0.12.98" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.9.3" installed="4.9.3" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.23.0" installed="0.23.0" location="./tools/infection" copy="false"/>
+</phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,50 +1,52 @@
 <?php
 
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
-        '@PHP71Migration' => true,
+        '@PSR12' => true,
+        '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
+        '@PHP73Migration' => true,
+        // PSR12 (remove when php-cs-fixer reaches ^3.1.1)
+        'class_definition' => ['space_before_parenthesis' => true],
         // symfony
-        'class_attributes_separation' => true,
+        // 'class_attributes_separation' => true, // conflict with PSR12
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'no_alias_functions' => true,
-        'trailing_comma_in_multiline_array' => true,
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
-        'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
+        'not_operator_with_successor_space' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
+            ->append([__FILE__])
             ->exclude(['vendor', 'build'])
     )
 ;

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,8 @@
 filter:
   excluded_paths:
     - 'tests/'
+  dependency_paths:
+    - 'tools/'
     - 'vendor/'
 
 build:
@@ -13,7 +15,5 @@ build:
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-          - command: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-            coverage:
-              file: coverage.clover
-              format: clover
+tools:
+  external_code_coverage: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Código de Conducta convenido para Contribuyentes
+# Código de Conducta Convenido para Contribuyentes
 
 ## Nuestro compromiso
 
@@ -36,7 +36,7 @@ Este código de conducta aplica tanto a espacios del proyecto como a espacios p�
 
 ## Aplicación
 
-Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [coc@phpcfdi.com](). Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [coc@phpcfdi.com](mailto:coc@phpcfdi.com). Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
 
 Todos los administradores de la comunidad están obligados a respetar la privacidad y la seguridad de quienes reporten incidentes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,14 +49,14 @@ o la forma de desarrollarlas puede que no estén alineadas con el proyecto.
 
 Considera las siguientes directrices:
 
-* Usa una rama única que se desprenda de la rama principal.
+* Usa una rama única que se desprenda de la rama principal. 
   No mezcles dos diferentes funcionalidades en una misma rama o *Pull Request*.
 * Describe claramente y en detalle los cambios que hiciste.
 * **Escribe pruebas** para la funcionalidad que deseas agregar.
-* **Asegúrate que las pruebas pasan** antes de enviar tu contribución.
-  Usamos integración contínua donde se hace esta verificación, pero es mucho mejor si lo pruebas localmente.
+* **Asegúrate que las pruebas pasan** antes de enviar tu contribución. 
+  Usamos integración continua donde se hace esta verificación, pero es mucho mejor si lo pruebas localmente.
 * Intenta enviar una historia coherente, entenderemos cómo cambia el código si los *commits* tienen significado.
-* La documentación es parte del proyecto.
+* La documentación es parte del proyecto. 
   Realiza los cambios en los archivos de ayuda para que reflejen los cambios en el código.
 
 ## Proceso de construcción
@@ -64,6 +64,7 @@ Considera las siguientes directrices:
 ```shell
 # Actualiza tus dependencias
 composer update
+phive update
 
 # Verificación de estilo de código
 composer dev:check-style
@@ -74,12 +75,22 @@ composer dev:fix-style
 # Ejecución de pruebas
 composer dev:test
 
-# Ejecución todo en uno, corregir estilo, verificar estilo y correr pruebas
+# Ejecución todo en uno: corregir estilo, verificar estilo y correr pruebas
 composer dev:build
+```
+
+## Ejecutar GitHub Actions localmente
+
+Puedes usar [`act`](https://github.com/nektos/act) para ejecutar GitHub Actions localmente, tal como se
+muestra en [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
+puedes ejecutar el siguiente comando:
+
+```shell
+act -P ubuntu-latest=shivammathur/node:latest
 ```
 
 [phpCfdi]:      https://github.com/phpcfdi/
 [project]:      https://github.com/phpcfdi/xml-cancelacion
 [contributors]: https://github.com/phpcfdi/xml-cancelacion/graphs/contributors
-[coc]:          https://github.com/phpcfdi/xml-cancelacion/blob/master/CODE_OF_CONDUCT.md
+[coc]:          https://github.com/phpcfdi/xml-cancelacion/blob/main/CODE_OF_CONDUCT.md
 [issues]:       https://github.com/phpcfdi/xml-cancelacion/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2021 PHPCFDI
+Copyright (c) 2019 - 2021 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > Genera documentos de cancelación de CFDI firmados (XMLSEC)
 
-:us: The documentation of this project is in spanish as this is the natural language for intented audience.
+:us: The documentation of this project is in spanish as this is the natural language for intended audience.
 
 :mexico: La documentación del proyecto está en español porque ese es el lenguaje principal de los usuarios.
 
@@ -81,7 +81,7 @@ $data = new Cancellation('LAN7008173R5', ['12345678-1234-1234-1234-123456789012'
 $xml = (new DOMSigner())->signCapsule($data, $credentials);
 ```
 
-La salida esperada es algo como lo siguiente (sin los espacios en blanco que agregué para mejor lectura).
+La salida esperada es algo como lo siguiente (sin los espacios en blanco, que agregué para mejor lectura).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -138,12 +138,12 @@ se obtiene el RFC directamente de las propiedades del certificado.
 
 Los métodos de ayuda utilizan una fecha opcional (`DateTimeImmutable` o `null`), si no se especifica
 entonces se toma la fecha actual del sistema, ten en cuenta que para la creación se utiliza el reloj
-del sistema y el uso horario. Si no estás seguro de poder controlar estas configuraciones te
+del sistema y el huso horario. Si no estás seguro de poder controlar estas configuraciones te
 recomiendo que establezcas el parámetro.
 
 ### Solicitud de cancelación
 
-Para crear la solicitud firmada se puede hacer con los métodos `signCancellation` para un sólo UUID
+Para crear la solicitud firmada se puede hacer con los métodos `signCancellation` para un solo UUID
 o `signCancellationUuids` para varios UUID. Como primer parámetro reciben qué UUID será cancelado.
 
 ### Solicitud de folios relacionados
@@ -161,12 +161,12 @@ y el RFC del PAC por el cual se realiza la consulta.
 ### Solicitud de cancelación de RET
 
 Existe un CFDI especial de *"Retenciones e información de pagos"*, donde también se requiere una solicitud
-firmada tal como en una cancelación de CFDI pero su contenido cambia.
+firmada tal como en una cancelación de CFDI, pero su contenido es diferente.
 
-Para crear la solicitud firmada para RET se puede hacer con los métodos `signRetentionCancellation` para un sólo UUID
+Para crear la solicitud firmada para RET se puede hacer con los métodos `signRetentionCancellation` para un solo UUID
 o `signRetentionCancellationUuids` para varios UUID. Como primer parámetro reciben qué UUID será cancelado.
 
-TIP: Por la experiencia en el uso de los servicios de SAT se comienda usar siempre cancelaciones individuales.
+TIP: Por la experiencia en el uso de los servicios de SAT es recomendado usar siempre cancelaciones individuales.
 
 ## Objetos de trabajo
 
@@ -177,12 +177,27 @@ poder generar el documento XML a firmar.
 **`Credentials`** Es un objeto que encapsula el trabajo con los certificados y llave privada.
 Internamente utiliza [`phpcfdi/credentials`](https://github.com/phpcfdi/credentials) y la clase interna es solo
 una indirección de `PhpCfdi\Credentials\Credential`. Incluso puedes crear una credencial de `phpcfd/xml-cancelacion`
-a partir de un objeto directo de `phpcfdi/credentials`. 
+a partir de un objeto directo de `phpcfdi/credentials` usando `Credentials::createWithPhpCfdiCredential`, por ejemplo:
+
+```php
+<?php
+declare(strict_types=1);
+use PhpCfdi\Credentials\Credential;
+use PhpCfdi\XmlCancelacion\Credentials;
+use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
+
+$phpCfdiCredential = Credential::openFiles('certificado.cer', 'llaveprivada.key', 'contraseña');
+$credentials = Credentials::createWithPhpCfdiCredential($phpCfdiCredential);
+
+$xmlCancelacion = new XmlCancelacionHelper($credentials);
+
+$solicitudCancelacion = $xmlCancelacion->signCancellation('11111111-2222-3333-4444-000000000001');
+```
 
 **`SignerInterface`** son los objetos que permiten firmar el documento generado por una *cápsula* y una *credencial*.
 Existen dos implementaciones: `DOMSigner` (recomendada) y `XmlSecLibsSigner`. La primera no requiere de mayores
 dependencias y realiza el firmado utilizando las especificaciones del SAT. La segunda utiliza *parcialmente*
-[XmlSecLibs](https://github.com/phpcfdi/xml-cancelacion/blob/master/XmlSecLibs.md) y termina la información de
+[XmlSecLibs](https://github.com/phpcfdi/xml-cancelacion/blob/main/docs/XmlSecLibs.md) y termina la información de
 la firma usando un mecanismo interno.
 
 ## Observaciones
@@ -192,13 +207,13 @@ Si bien, esto no es necesario para producir un documento con la firma correcta, 
 producir la información que se requiere por parte del PAC o del SAT.
 
 A partir de 2019-08-27 con la versión `1.0.0` se puede usar [`robrichards/xmlseclibs`](https://github.com/robrichards/xmlseclibs).
-Para más información ver el archivo [XmlSecLibs](https://github.com/phpcfdi/xml-cancelacion/blob/master/XmlSecLibs.md).
+Para más información ver el archivo [XmlSecLibs](https://github.com/phpcfdi/xml-cancelacion/blob/main/docs/XmlSecLibs.md).
 
 A partir de 2019-08-13 con la versión `0.4.0` se eliminó la dependencia a `eclipxe/cfdiutils` y se cambió a la
 librería [`phpcfdi/credentials`](https://github.com/phpcfdi/xml-cancelacion), con esta nueva dependencia se trabaja
 mucho mejor con los certificados y llaves privadas.
 
-## Compatilibilidad
+## Compatibilidad
 
 Esta librería se mantendrá compatible con al menos la versión con
 [soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.
@@ -216,22 +231,22 @@ y recuerda revisar el archivo de tareas pendientes [TODO][] y el archivo [CHANGE
 The `phpcfdi/xml-cancelacion` library is copyright © [PhpCfdi](https://www.phpcfdi.com/)
 and licensed for use under the MIT License (MIT). Please see [LICENSE][] for more information.
 
-[contributing]: https://github.com/phpcfdi/xml-cancelacion/blob/master/CONTRIBUTING.md
-[changelog]: https://github.com/phpcfdi/xml-cancelacion/blob/master/docs/CHANGELOG.md
-[todo]: https://github.com/phpcfdi/xml-cancelacion/blob/master/docs/TODO.md
+[contributing]: https://github.com/phpcfdi/xml-cancelacion/blob/main/CONTRIBUTING.md
+[changelog]: https://github.com/phpcfdi/xml-cancelacion/blob/main/docs/CHANGELOG.md
+[todo]: https://github.com/phpcfdi/xml-cancelacion/blob/main/docs/TODO.md
 
 [source]: https://github.com/phpcfdi/xml-cancelacion
 [release]: https://github.com/phpcfdi/xml-cancelacion/releases
-[license]: https://github.com/phpcfdi/xml-cancelacion/blob/master/LICENSE
-[build]: https://github.com/phpcfdi/xml-cancelacion/actions/workflows/build.yml?query=branch:master
+[license]: https://github.com/phpcfdi/xml-cancelacion/blob/main/LICENSE
+[build]: https://github.com/phpcfdi/xml-cancelacion/actions/workflows/build.yml?query=branch:main
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/xml-cancelacion/
-[coverage]: https://scrutinizer-ci.com/g/phpcfdi/xml-cancelacion/code-structure/master/code-coverage/src/
+[coverage]: https://scrutinizer-ci.com/g/phpcfdi/xml-cancelacion/code-structure/main/code-coverage
 [downloads]: https://packagist.org/packages/phpcfdi/xml-cancelacion
 
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/xml--cancelacion-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/xml-cancelacion?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/xml-cancelacion?style=flat-square
-[badge-build]: https://img.shields.io/travis/com/phpcfdi/xml-cancelacion/master?style=flat-square
+[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/xml-cancelacion/build/main?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/xml-cancelacion/main?style=flat-square
-[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/xml-cancelacion/master?style=flat-square
+[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/xml-cancelacion/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/xml-cancelacion?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
         "ext-dom": "*",
         "ext-openssl": "*",
         "eclipxe/enum": "^0.2",
@@ -30,10 +30,7 @@
     },
     "require-dev": {
         "robrichards/xmlseclibs": "^3.1.0",
-        "phpunit/phpunit": "^8.3.5",
-        "squizlabs/php_codesniffer": "^3.0",
-        "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.12.54"
+        "phpunit/phpunit": "^9.5"
     },
     "suggest": {
         "robrichards/xmlseclibs": "Create document signatures (partially) using xmlseclibs"
@@ -51,27 +48,29 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
-            "vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
-            "vendor/bin/php-cs-fixer fix --verbose",
-            "vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php tools/php-cs-fixer fix --verbose",
+            "@php tools/phpcbf --colors -sp"
         ],
         "dev:test": [
             "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "vendor/bin/phpstan analyse --verbose --no-progress --level max src/ tests/"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php tools/phpstan analyse --no-progress",
+            "@php tools/psalm --no-progress",
+            "@php tools/infection --no-progress --no-interaction --show-mutations"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
-        "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
+        "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:check-style, phpunit and phpstan",
+        "dev:test": "DEV: run dev:check-style, phpunit, phpstan, psalm and infection",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,17 +1,39 @@
 # CHANGELOG
 
-## UNRELEASED 2021-01-12
+## Acerca de SemVer
+
+Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta librería sin temor a romper tu aplicación.
+
+## Cambios no liberados en una versión
+
+Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
+versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
+
+## Listado de cambios
+
+### Versión 1.1.2 2020-01-23
+
+- La versión menor de PHP es 7.3.
+- Se actualiza PHPUnit a 9.5.
+- Se migra de Travis-CI a GitHub Workflows. Gracias Travis-CI.
+- Se instalan las herramientas de desarrollo usando `phive` en lugar de `composer`.
+- Se agregan revisiones de `psalm` e `infection`.
+- Se cambia la rama principal a `main`.
+- Se agrega un `trait` interno para obtener el elemento principal de un documento XML.
+- Se usan constantes privadas descriptivas en lugar de números mágicos.
+
+### UNRELEASED 2021-01-12
 
 - La documentación del proyecto cambia a español.
 - Se agrega PHP 8.0 a la integración continua.
 - Se modifican los comandos de construcción para usar composer versión 2.
 - Actualización del año en la licencia, feliz 2021 desde PhpCfdi.
 
-## UNRELEASED 2020-11-12
+### UNRELEASED 2020-11-12
 
 - Fix Travis-CI build: `phpstan: ^0.12.54` detects issues on unit tests control flow.
 
-## Version 1.1.1 2020-08-28
+### Version 1.1.1 2020-08-28
 
 - Refactor `CreateKeyInfoElementTraitTest` explaining what it is for.
     - Add a class to use `CreateKeyInfoElementTrait` changing `createKeyInfoElement` method visibility.
@@ -19,7 +41,7 @@
     - Fixes recently (false positive) issue detected by `phpstan/phpstan:^0.12.40`.
 - Change dependency `robrichards/xmlseclibs` version from `^3.0.8` to `3.1.0`.
 
-## Version 1.1.0 2020-01-23
+### Version 1.1.0 2020-01-23
 
 - Update license year, happy 2020!
 - Include cancellation document for document *"CFDI de retención e información de pagos"*.
@@ -37,19 +59,19 @@
     - Create a testing class `XmlCancelacionHelperSpy` to spy on `XmlCancelacionHelper`.
     - Refactor tests on `XmlCancelacionHelperTest` to test against the spy class.  
 
-## Version 1.0.1 2019-10-02
+### Version 1.0.1 2019-10-02
 
 - Fix documentation to point out version 1.0 instead of 0.5.
 - Fix documentation PHP examples.
 
-## Version 1.0.0 2019-09-28
+### Version 1.0.0 2019-09-28
 
 - This version is a major change, it is not compatible with previous versions
-  Read [UPGRADE-1.0](https://github.com/phpcfdi/xml-cancelacion/blob/master/docs/UPGRADE-1.0.md)
+  Read [UPGRADE-1.0](https://github.com/phpcfdi/xml-cancelacion/blob/main/docs/UPGRADE-1.0.md)
 - New signed documents:
-    - Cancellation: For request to SAT a cancellation of one or many CFDI.
-    - ObtainRelated: For asking to SAT related documents of a CFDI.
-    - CancellationAnswer: For setting the answer to SAT about a cancellation request.
+    - Cancellation: Request SAT for cancellation of one or many CFDI.
+    - ObtainRelated: Request SAT for related documents of a CFDI.
+    - CancellationAnswer: Answer SAT about a cancellation request.
 - New project concepts:
     - Capsule: DTO that contains source data, also implements `CapsuleInterface`
     - Signer: Manipulation object implementing `SignerInterface`, takes a DOMDocument and append signature data
@@ -71,14 +93,14 @@
             - `CertificateIsNotCSD`
 
 
-## Version 0.4.2 2019-09-05
+### Version 0.4.2 2019-09-05
 
 - Include a helper object `XmlCancelacionHelper` that simplify working with this library,
-  see [README](https://github.com/phpcfdi/xml-cancelacion/blob/master/README.md) for usage.
+  see [README](https://github.com/phpcfdi/xml-cancelacion/blob/main/README.md) for usage.
 - Other minimal changes on documentation.
 
 
-## Version 0.4.1 2019-08-13
+### Version 0.4.1 2019-08-13
 
 - Fix X509IssuerName to use certificate issuer as [RFC 4514](https://www.ietf.org/rfc/rfc4514.txt)
   according to [XML Signature Syntax and Processing Version 1.1](https://www.w3.org/TR/xmldsig-core1/)
@@ -89,7 +111,7 @@
   Notice that in the encoding rules mention additional rules that __MAY__ be implemented. We are not. 
 
 
-## Version 0.4.0 2019-08-13
+### Version 0.4.0 2019-08-13
 
 - Drop dependence from `eclipxe/cfdiutils` to `phpcfdi/credentials`
 - `PhpCfdi\XmlCancelacion\Credentials` changed from DTO to encapsulate certificate & private key logic:
@@ -98,7 +120,7 @@
 - Minor improvements in documentation
 
 
-## Version 0.3.0 2019-06-27
+### Version 0.3.0 2019-06-27
 
 - Fix issue when calling `DOMDocument::createElement`/`DOMDocument::createElementNS` and content has an empersand `&`:
     - `KeyInfo/X509Data/X509IssuerSerial/X509IssuerName`
@@ -112,12 +134,12 @@
 - Remove protected method `DOMSigner::createKeyValueFromCertificado` in favor of `DOMSigner::createKeyValueElement`.
 
 
-## Version 0.2.1 2019-05-13
+### Version 0.2.1 2019-05-13
 
 - Release with new tag since v0.2.0 did not include this changes
 
 
-## Version 0.2.0 2019-05-13
+### Version 0.2.0 2019-05-13
 
 - Code quality improvements thanks to phpstan and infection (mutation testing framework)
 - Remove `Capsule::append` method, `Capsule` is now immutable.
@@ -125,6 +147,6 @@
 - `Capsule` now implements `Countable`
 
 
-## Version 0.1.0 2019-04-09
+### Version 0.1.0 2019-04-09
 
 - First public version

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -3,7 +3,7 @@
 Respetamos el estándar [Versionado Semántico 2.0.0](https://semver.org/lang/es/).
 
 En resumen, [SemVer](https://semver.org/) es un sistema de versiones de tres componentes `X.Y.Z`
-que nombraremos así: ` Breaking . Feature . Fix `, donde:
+que nombraremos ` Breaking . Feature . Fix `, donde:
 
 - `Breaking`: Rompe la compatibilidad de código con versiones anteriores.
 - `Feature`: Agrega una nueva característica que es compatible con lo anterior.
@@ -11,9 +11,9 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 
 ## Composer
 
-[Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
-Este gestor usa las [reglas](https://getcomposer.org/doc/articles/versions.md)
-de versionado semántico para instalar y actualizar paquetes.
+El gestor de dependencias en proyectos para PHP [Composer](https://getcomposer.org/) 
+usa las [reglas](https://getcomposer.org/doc/articles/versions.md) de versionado semántico
+para instalar y actualizar paquetes.
 
 Te recomendamos instalar dependencias de librerías (no frameworks) con *Caret Version Range*.
 Por ejemplo: `"vendor/package": "^2.5"`.
@@ -23,7 +23,7 @@ Esto significa que:
 - no debe actualizar a versiones `3.x.x`
 - no debe utilizar ninguna versión menor a `2.5.0`
 
-## Versiones 0.x.y no rompe compatibilidad
+## Versiones 0.x.y no rompen compatibilidad
 
 Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reglas de versionado.
 Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto
@@ -31,9 +31,8 @@ introducen cambios sin previo aviso.
 
 ## `@internal` no rompe compatibilidad
 
-Si la librería contiene elementos marcados como `@internal` significa que no deben ser utilizados
-por tu código. Son partes de código internos de la librería.
-Por lo tanto, no se consideran breaking changes.
+Si la librería contiene elementos marcados como `@internal` significa que no deben ser utilizados por tu código.
+Son partes de código internos de la librería. Por lo tanto, no se consideran *breaking changes*.
 
 Cuando un elemento es `@internal`, dicho elemento:
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,8 +2,10 @@
 
 ## Pendientes
 
-- El tercer parámetro del constructor de `Cancellation` que recibe el `DocumentType` debería ser obligatorio,
+- El tercer parámetro del constructor de `Cancellation` que recibe el valor `DocumentType` debería ser obligatorio,
   es opcional para compatibilidad con la versión actual.
+
+- Mejorar los casos de cobertura de código para hacer mandatorio `infection` en los pasos de construcción.
 
 ## Resueltas
 

--- a/docs/XmlSecLibs.md
+++ b/docs/XmlSecLibs.md
@@ -3,8 +3,9 @@
 A partir de la versión `1.0.0` se incluye un objeto `XmlSecLibsSigner` que implementa `SignerInterface`.
 
 Se puede utilizar [`robrichards/xmlseclibs`](https://github.com/robrichards/xmlseclibs) para hacer el firmado,
-sin embargo al 2019-04-09 aun no se han implementado los mecanismos para incluir el elemento `KeyValue`,
-a pesar de tener un [PR #75](https://github.com/robrichards/xmlseclibs/pull/75) desde 2015-09-03.
+sin embargo al 2019-04-09 aún no se han implementado los mecanismos para incluir el elemento `KeyValue`,
+a pesar de tener un [PR #75](https://github.com/robrichards/xmlseclibs/pull/75) desde 2015-09-03
+y un [ISSUE #217](https://github.com/robrichards/xmlseclibs/issues/217).
 
 Las otras dos desventajas están en la forma en que escribe los valores de `X509IssuerSerial`,
 tanto `X509IssuerName` como `X509SerialNumber`.

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,15 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "build\/infection.log"
+    },
+    "mutators": {
+        "@default": true
+    },
+    "initialTestsPhpOptions": "-dzend_extension=xdebug.so -dxdebug.mode=coverage"
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,11 +1,17 @@
 <?xml version="1.0"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-2 based) coding standard.</description>
+
+    <file>src</file>
+    <file>tests</file>
+
     <arg name="tab-width" value="4"/>
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
-    <rule ref="PSR2"/>
+    <arg name="cache" value="build/phpcs.cache"/>
+
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
 parameters:
-    inferPrivatePropertyTypeFromConstructor: true
-
+    level: max
+    paths:
+        - src/
+        - tests/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,18 @@
-<phpunit xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="./tests/bootstrap.php" colors="true" verbose="true" cacheResult="false">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    cacheResultFile="build/phpunit.result.cache"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    >
     <testsuites>
-        <testsuite name="Default">
-            <directory>./tests/</directory>
+        <testsuite name="default">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <!-- exclude composer vendor folder -->
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm xmlns="https://getpsalm.org/schema/config"
+    resolveFromConfigFile="true"
+    totallyTyped="true">
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/src/Capsules/BaseDocumentBuilder.php
+++ b/src/Capsules/BaseDocumentBuilder.php
@@ -16,6 +16,10 @@ use DOMDocument;
  */
 class BaseDocumentBuilder
 {
+    private const XMLDOC_NO_PRESERVE_WHITESPACE = false;
+
+    private const XMLDOC_NO_FORMAT_OUTPUT = false;
+
     /** @var array<string, string> */
     private $extraNamespaces;
 
@@ -55,8 +59,8 @@ class BaseDocumentBuilder
     public function createBaseDocument(string $tagName, string $namespace): DOMDocument
     {
         $document = new DOMDocument('1.0', 'UTF-8');
-        $document->preserveWhiteSpace = false;
-        $document->formatOutput = false;
+        $document->preserveWhiteSpace = self::XMLDOC_NO_PRESERVE_WHITESPACE;
+        $document->formatOutput = self::XMLDOC_NO_FORMAT_OUTPUT;
         $cancelacion = $document->createElementNS($namespace, $tagName);
         foreach ($this->extraNamespaces() as $prefix => $uri) {
             $cancelacion->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:' . $prefix, $uri);

--- a/src/Capsules/BaseDocumentBuilder.php
+++ b/src/Capsules/BaseDocumentBuilder.php
@@ -45,9 +45,7 @@ class BaseDocumentBuilder
         return $this->extraNamespaces;
     }
 
-    /**
-     * @return array<string| string>
-     */
+    /** @return array<string, string> */
     public static function defaultExtraNamespaces(): array
     {
         return [

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -7,11 +7,13 @@ namespace PhpCfdi\XmlCancelacion\Capsules;
 use Countable;
 use DateTimeImmutable;
 use DOMDocument;
-use DOMElement;
 use PhpCfdi\XmlCancelacion\Definitions\DocumentType;
+use PhpCfdi\XmlCancelacion\Internal\XmlHelperFunctions;
 
 class Cancellation implements Countable, CapsuleInterface
 {
+    use XmlHelperFunctions;
+
     /** @var string */
     private $rfc;
 
@@ -25,7 +27,7 @@ class Cancellation implements Countable, CapsuleInterface
     private $documentType;
 
     /**
-     * DTO for cancellation request, it support CFDI and Retention
+     * DTO for cancellation request, it supports CFDI and Retention
      *
      * @param string $rfc
      * @param string[] $uuids
@@ -76,8 +78,7 @@ class Cancellation implements Countable, CapsuleInterface
     {
         $document = (new BaseDocumentBuilder())->createBaseDocument('Cancelacion', $this->documentType->value());
 
-        /** @var DOMElement $cancelacion */
-        $cancelacion = $document->documentElement;
+        $cancelacion = $this->xmlDocumentElement($document);
         $cancelacion->setAttribute('RfcEmisor', $this->rfc()); // en el anexo 20 es opcional!
         $cancelacion->setAttribute('Fecha', $this->date()->format('Y-m-d\TH:i:s'));
         $folios = $cancelacion->appendChild($document->createElement('Folios'));

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -14,6 +14,8 @@ class Cancellation implements Countable, CapsuleInterface
 {
     use XmlHelperFunctions;
 
+    private const UUID_EXISTS = true;
+
     /** @var string */
     private $rfc;
 
@@ -41,7 +43,7 @@ class Cancellation implements Countable, CapsuleInterface
         $this->uuids = [];
         $this->documentType = $type ?? DocumentType::cfdi();
         foreach ($uuids as $uuid) {
-            $this->uuids[strtoupper($uuid)] = true;
+            $this->uuids[strtoupper($uuid)] = self::UUID_EXISTS;
         }
     }
 

--- a/src/Capsules/CancellationAnswer.php
+++ b/src/Capsules/CancellationAnswer.php
@@ -6,12 +6,14 @@ namespace PhpCfdi\XmlCancelacion\Capsules;
 
 use DateTimeImmutable;
 use DOMDocument;
-use DOMElement;
 use PhpCfdi\XmlCancelacion\Definitions\CancelAnswer;
 use PhpCfdi\XmlCancelacion\Definitions\DocumentType;
+use PhpCfdi\XmlCancelacion\Internal\XmlHelperFunctions;
 
 class CancellationAnswer implements CapsuleInterface
 {
+    use XmlHelperFunctions;
+
     /** @var string */
     private $uuid;
 
@@ -71,8 +73,7 @@ class CancellationAnswer implements CapsuleInterface
         $document = (new BaseDocumentBuilder())
             ->createBaseDocument('SolicitudAceptacionRechazo', DocumentType::cfdi()->value());
 
-        /** @var DOMElement $solicitudAceptacionRechazo */
-        $solicitudAceptacionRechazo = $document->documentElement;
+        $solicitudAceptacionRechazo = $this->xmlDocumentElement($document);
         $solicitudAceptacionRechazo->setAttribute('Fecha', $this->dateTime()->format('Y-m-d\TH:i:s'));
         $solicitudAceptacionRechazo->setAttribute('RfcPacEnviaSolicitud', $this->pacRfc());
         $solicitudAceptacionRechazo->setAttribute('RfcReceptor', $this->rfc());

--- a/src/Capsules/ObtainRelated.php
+++ b/src/Capsules/ObtainRelated.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace PhpCfdi\XmlCancelacion\Capsules;
 
 use DOMDocument;
-use DOMElement;
 use PhpCfdi\XmlCancelacion\Definitions;
 use PhpCfdi\XmlCancelacion\Definitions\DocumentType;
 use PhpCfdi\XmlCancelacion\Definitions\RfcRole;
+use PhpCfdi\XmlCancelacion\Internal\XmlHelperFunctions;
 
 class ObtainRelated implements CapsuleInterface
 {
+    use XmlHelperFunctions;
+
     /** @var string */
     private $uuid;
 
@@ -57,8 +59,7 @@ class ObtainRelated implements CapsuleInterface
         $document = (new BaseDocumentBuilder())
             ->createBaseDocument('PeticionConsultaRelacionados', DocumentType::cfdi()->value());
 
-        /** @var DOMElement $peticion */
-        $peticion = $document->documentElement;
+        $peticion = $this->xmlDocumentElement($document);
         $peticion->setAttribute('RfcEmisor', ($this->role()->isIssuer()) ? $this->rfc() : '');
         $peticion->setAttribute('RfcPacEnviaSolicitud', $this->pacRfc());
         $peticion->setAttribute('RfcReceptor', ($this->role()->isReceiver()) ? $this->rfc() : '');

--- a/src/Internal/XmlHelperFunctions.php
+++ b/src/Internal/XmlHelperFunctions.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Internal;
+
+use DOMDocument;
+use DOMElement;
+use PhpCfdi\XmlCancelacion\Exceptions\DocumentWithoutRootElement;
+
+/** @internal */
+trait XmlHelperFunctions
+{
+    /**
+     * Get the document's root element. Throw an exception if not exists.
+     *
+     * @param DOMDocument $document
+     * @return DOMElement
+     * @throws DocumentWithoutRootElement
+     */
+    private function xmlDocumentElement(DOMDocument $document): DOMElement
+    {
+        /**
+         * Static analysis tools (PHPStan and PhpStorm) does not recognize the correct type
+         * @var DOMElement|null $documentElement
+         */
+        $documentElement = $document->documentElement;
+        if (null === $documentElement) {
+            throw new DocumentWithoutRootElement();
+        }
+        return $documentElement;
+    }
+}

--- a/src/Signers/CreateKeyInfoElementTrait.php
+++ b/src/Signers/CreateKeyInfoElementTrait.php
@@ -53,9 +53,9 @@ trait CreateKeyInfoElementTrait
      */
     private function createKeyValueElement(DOMDocument $document, array $pubKeyData): DOMElement
     {
+        /** @var array{type: int, rsa: array{n: string, e: string}} $pubKeyData */
         $keyValue = $document->createElement('KeyValue');
-        $type = $pubKeyData['type'] ?? -1;
-        if (OPENSSL_KEYTYPE_RSA === $type) {
+        if (OPENSSL_KEYTYPE_RSA === $pubKeyData['type']) {
             $rsaKeyValue = $keyValue->appendChild($document->createElement('RSAKeyValue'));
             $rsaKeyValue->appendChild($document->createElement('Modulus', base64_encode($pubKeyData['rsa']['n'])));
             $rsaKeyValue->appendChild($document->createElement('Exponent', base64_encode($pubKeyData['rsa']['e'])));

--- a/src/Signers/DOMSigner.php
+++ b/src/Signers/DOMSigner.php
@@ -17,6 +17,18 @@ class DOMSigner implements SignerInterface
 
     use XmlHelperFunctions;
 
+    private const C14N_INCLUSIVE = false;
+
+    private const C14N_WITHOUT_COMMENTS = false;
+
+    private const IMPORT_NODE_DEEP = true;
+
+    private const XMLDOC_NO_PRESERVE_WHITESPACE = false;
+
+    private const XMLDOC_NO_FORMAT_OUTPUT = false;
+
+    private const SHA1_BINARY = true;
+
     /** @var string */
     private $digestSource = '';
 
@@ -53,8 +65,8 @@ class DOMSigner implements SignerInterface
     {
         // Setup digestSource & digestValue
         // C14N: no exclusive, no comments (if exclusive will drop not used namespaces)
-        $this->digestSource = $document->C14N(false, false);
-        $this->digestValue = base64_encode(sha1($this->digestSource, true));
+        $this->digestSource = $document->C14N(self::C14N_INCLUSIVE, self::C14N_WITHOUT_COMMENTS);
+        $this->digestValue = base64_encode(sha1($this->digestSource, self::SHA1_BINARY));
 
         /** @var DOMElement $signature */
         $signature = $document->createElementNS('http://www.w3.org/2000/09/xmldsig#', 'Signature');
@@ -62,13 +74,13 @@ class DOMSigner implements SignerInterface
 
         // SignedInfo: import in document and append to the Signature element
         $signedInfo = $signature->appendChild(
-            $document->importNode($this->createSignedInfoElement(), true)
+            $document->importNode($this->createSignedInfoElement(), self::IMPORT_NODE_DEEP)
         );
 
         // need to append signature to document and signed info **before** C14N
         // otherwise the signedinfo will not contain namespaces
         // C14N: no exclusive, no comments (if exclusive will drop not used namespaces)
-        $this->signedInfoSource = $signedInfo->C14N(false, false);
+        $this->signedInfoSource = $signedInfo->C14N(self::C14N_INCLUSIVE, self::C14N_WITHOUT_COMMENTS);
         $this->signedInfoValue = base64_encode($credentials->sign($this->signedInfoSource, OPENSSL_ALGO_SHA1));
 
         // SIGNATUREVALUE
@@ -84,7 +96,7 @@ class DOMSigner implements SignerInterface
             $credentials->certificateAsPEM(),
             $credentials->publicKeyData()
         );
-        $signature->appendChild($document->importNode($keyInfoElement, true));
+        $signature->appendChild($document->importNode($keyInfoElement, self::IMPORT_NODE_DEEP));
     }
 
     protected function createSignedInfoElement(): DOMElement
@@ -102,8 +114,8 @@ class DOMSigner implements SignerInterface
             </SignedInfo>';
 
         $docInfo = new DOMDocument();
-        $docInfo->preserveWhiteSpace = false;
-        $docInfo->formatOutput = false;
+        $docInfo->preserveWhiteSpace = self::XMLDOC_NO_PRESERVE_WHITESPACE;
+        $docInfo->formatOutput = self::XMLDOC_NO_FORMAT_OUTPUT;
         $docInfo->loadXML($template);
         return $this->xmlDocumentElement($docInfo);
     }

--- a/src/Signers/DOMSigner.php
+++ b/src/Signers/DOMSigner.php
@@ -7,12 +7,15 @@ namespace PhpCfdi\XmlCancelacion\Signers;
 use DOMDocument;
 use DOMElement;
 use PhpCfdi\XmlCancelacion\Credentials;
-use PhpCfdi\XmlCancelacion\Exceptions\DocumentWithoutRootElement;
+use PhpCfdi\XmlCancelacion\Internal\XmlHelperFunctions;
 
 class DOMSigner implements SignerInterface
 {
     use CreateKeyInfoElementTrait;
+
     use SignCapsuleMethodTrait;
+
+    use XmlHelperFunctions;
 
     /** @var string */
     private $digestSource = '';
@@ -25,20 +28,6 @@ class DOMSigner implements SignerInterface
 
     /** @var string */
     private $signedInfoValue = '';
-
-    /**
-     * @param DOMDocument $document
-     * @return DOMElement
-     */
-    private function rootElement(DOMDocument $document): DOMElement
-    {
-        /** @var DOMElement|null $rootElement help static analyzers to detect that documentElement can be null */
-        $rootElement = $document->documentElement;
-        if (null === $rootElement) {
-            throw new DocumentWithoutRootElement();
-        }
-        return $rootElement;
-    }
 
     public function getDigestSource(): string
     {
@@ -69,7 +58,7 @@ class DOMSigner implements SignerInterface
 
         /** @var DOMElement $signature */
         $signature = $document->createElementNS('http://www.w3.org/2000/09/xmldsig#', 'Signature');
-        $this->rootElement($document)->appendChild($signature);
+        $this->xmlDocumentElement($document)->appendChild($signature);
 
         // SignedInfo: import in document and append to the Signature element
         $signedInfo = $signature->appendChild(
@@ -116,8 +105,6 @@ class DOMSigner implements SignerInterface
         $docInfo->preserveWhiteSpace = false;
         $docInfo->formatOutput = false;
         $docInfo->loadXML($template);
-        $docinfoNode = $this->rootElement($docInfo);
-
-        return $docinfoNode;
+        return $this->xmlDocumentElement($docInfo);
     }
 }

--- a/src/Signers/XmlSecLibsSigner.php
+++ b/src/Signers/XmlSecLibsSigner.php
@@ -9,22 +9,21 @@ use DOMElement;
 use Exception;
 use LogicException;
 use PhpCfdi\XmlCancelacion\Credentials;
-use PhpCfdi\XmlCancelacion\Exceptions\DocumentWithoutRootElement;
+use PhpCfdi\XmlCancelacion\Internal\XmlHelperFunctions;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class XmlSecLibsSigner implements SignerInterface
 {
+    use XmlHelperFunctions;
+
     use CreateKeyInfoElementTrait;
+
     use SignCapsuleMethodTrait;
 
     public function signDocument(DOMDocument $document, Credentials $credentials): void
     {
-        /** @var DOMElement|null $rootElement help static analyzers to detect that documentElement can be null */
-        $rootElement = $document->documentElement;
-        if (! $rootElement instanceof DOMElement) {
-            throw new DocumentWithoutRootElement();
-        }
+        $this->xmlDocumentElement($document);
 
         try {
             // move XmlSecLibs signature to internal method
@@ -83,8 +82,7 @@ class XmlSecLibsSigner implements SignerInterface
         $objKey->passphrase = $credentials->passPhrase();
         $objKey->loadKey($credentials->privateKey(), true);
 
-        /** @var DOMElement $rootElement */
-        $rootElement = $document->documentElement;
+        $rootElement = $this->xmlDocumentElement($document);
         // Sign the XML file, set the second parameter to document element,
         // if second parameter is empty it will remove extra namespaces
         $objDSig->sign($objKey, $rootElement);

--- a/src/Signers/XmlSecLibsSigner.php
+++ b/src/Signers/XmlSecLibsSigner.php
@@ -53,11 +53,11 @@ class XmlSecLibsSigner implements SignerInterface
      */
     protected function signDocumentInternal(DOMDocument $document, Credentials $credentials): DOMElement
     {
-        // use a mofidied version of XMLSecurityDSig that does not contains xml white-spaces
-        $objDSig = new class('') extends XMLSecurityDSig {
-            public function __construct(string $prefix)
+        // use a modified version of XMLSecurityDSig that does not contain xml white-spaces
+        $objDSig = new class () extends XMLSecurityDSig {
+            /** @noinspection PhpMissingParentConstructorInspection */
+            public function __construct()
             {
-                parent::__construct($prefix);
                 // set sigNode property with a signature node without inner spaces
                 $document = new DOMDocument();
                 $document->appendChild($signature = $document->createElementNS(parent::XMLDSIGNS, 'Signature'))
@@ -87,11 +87,11 @@ class XmlSecLibsSigner implements SignerInterface
         // if second parameter is empty it will remove extra namespaces
         $objDSig->sign($objKey, $rootElement);
 
+        /**
+         * @noinspection PhpUnnecessaryLocalVariableInspection
+         * @var DOMElement $sigNode
+         */
         $sigNode = $objDSig->sigNode;
-        if (! $sigNode instanceof DOMElement) {
-            /** @codeCoverageIgnore */
-            throw new Exception('Signature node does not exists after sign');
-        }
 
         return $sigNode;
     }

--- a/tests/Unit/Capsules/BaseDocumentBuilderTest.php
+++ b/tests/Unit/Capsules/BaseDocumentBuilderTest.php
@@ -49,6 +49,6 @@ class BaseDocumentBuilderTest extends TestCase
             . '<fake xmlns="http://tempuri.org/fake"'
             . ' xmlns:xsd="http://www.w3.org/2001/XMLSchema"'
             . ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>';
-        $this->assertXmlStringEqualsXmlString($expectedXml, $document);
+        $this->assertXmlStringEqualsXmlString($expectedXml, (string) $document->saveXML());
     }
 }

--- a/tests/Unit/Capsules/CancellationAnswerTest.php
+++ b/tests/Unit/Capsules/CancellationAnswerTest.php
@@ -31,6 +31,6 @@ class CancellationAnswerTest extends TestCase
         $this->assertFalse($capsule->belongsToRfc($pacRfc));
 
         $expectedFile = $this->filePath('cancellation-answer-document.xml');
-        $this->assertXmlStringEqualsXmlFile($expectedFile, $capsule->exportToDocument());
+        $this->assertXmlStringEqualsXmlFile($expectedFile, (string) $capsule->exportToDocument()->saveXML());
     }
 }

--- a/tests/Unit/Capsules/CancellationTest.php
+++ b/tests/Unit/Capsules/CancellationTest.php
@@ -15,14 +15,15 @@ class CancellationTest extends TestCase
     {
         $rfc = 'LAN7008173R5';
         $uuids = [
-            '12345678-1234-1234-1234-123456789001',
-            '12345678-1234-1234-1234-123456789002',
+            '12345678-1234-aaaa-1234-123456789001',
+            '12345678-1234-aaaa-1234-123456789002',
         ];
+        $expectedUuids = array_map('strtoupper', $uuids);
         $date = new DateTimeImmutable('2019-01-13 14:15:16');
         $documentType = DocumentType::cfdi();
         $cancellation = new Cancellation($rfc, $uuids, $date, $documentType);
         $this->assertSame($rfc, $cancellation->rfc());
-        $this->assertSame($uuids, $cancellation->uuids());
+        $this->assertSame($expectedUuids, $cancellation->uuids());
         $this->assertSame($date, $cancellation->date());
         $this->assertSame($documentType, $cancellation->documentType());
 
@@ -61,7 +62,7 @@ class CancellationTest extends TestCase
         $dateTime = new DateTimeImmutable('2019-01-13 14:15:16');
         $cancellation = new Cancellation('LAN7008173R5', $uuids, $dateTime);
         $expectedFile = $this->filePath('cancellation-document.xml');
-        $this->assertXmlStringEqualsXmlFile($expectedFile, $cancellation->exportToDocument());
+        $this->assertXmlStringEqualsXmlFile($expectedFile, (string) $cancellation->exportToDocument()->saveXML());
     }
 
     public function testExportToDocumentWithRetention(): void
@@ -70,7 +71,7 @@ class CancellationTest extends TestCase
         $dateTime = new DateTimeImmutable('2019-01-13 14:15:16');
         $cancellation = new Cancellation('LAN7008173R5', $uuids, $dateTime, DocumentType::retention());
         $expectedFile = $this->filePath('cancellation-retention-document.xml');
-        $this->assertXmlStringEqualsXmlFile($expectedFile, $cancellation->exportToDocument());
+        $this->assertXmlStringEqualsXmlFile($expectedFile, (string) $cancellation->exportToDocument()->saveXML());
     }
 
     public function testCreateDocumentWithAmpersandsOnUuids(): void

--- a/tests/Unit/Capsules/ObtainRelatedTest.php
+++ b/tests/Unit/Capsules/ObtainRelatedTest.php
@@ -28,6 +28,6 @@ class ObtainRelatedTest extends TestCase
         $this->assertFalse($capsule->belongsToRfc($pacRfc));
 
         $expectedFile = $this->filePath('obtain-related-document.xml');
-        $this->assertXmlStringEqualsXmlFile($expectedFile, $capsule->exportToDocument());
+        $this->assertXmlStringEqualsXmlFile($expectedFile, (string) $capsule->exportToDocument()->saveXML());
     }
 }

--- a/tests/Unit/Signers/CreateKeyInfoElementTraitTest.php
+++ b/tests/Unit/Signers/CreateKeyInfoElementTraitTest.php
@@ -6,13 +6,14 @@ namespace PhpCfdi\XmlCancelacion\Tests\Unit\Signers;
 
 use DOMDocument;
 use DOMElement;
+use PhpCfdi\XmlCancelacion\Signers\CreateKeyInfoElementTrait;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
 
 /**
  * This test case is specifically created to test ampersands contents when building the XML using
  * \DOMDocument::createElement on CreateKeyInfoElementTrait::createKeyInfoElement.
  *
- * The text contents must be parsed previously as valid XML and it produces malformed contents when they are not.
+ * The text contents must be parsed previously as valid XML, and it produces malformed contents when they are not.
  *
  * It is using the local class CreateKeyInfoElementTraitImplementor to be able to expose the createKeyInfoElement
  * method, it is originally created as protected and the implementor class make it public.


### PR DESCRIPTION
- La versión menor de PHP es 7.3.
- Se actualiza PHPUnit a 9.5.
- Se migra de Travis-CI a GitHub Workflows. Gracias Travis-CI.
- Se instalan las herramientas de desarrollo usando `phive` en lugar de `composer`.
- Se agregan revisiones de `psalm` e `infection`.
- Se cambia la rama principal a `main`.
- Se agrega un `trait` interno para obtener el elemento principal de un documento XML.
- Se usan constantes privadas descriptivas en lugar de números mágicos.