### PR TITLE
Separar los XML Namespaces de cancelación

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,10 +11,17 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 2.0.1 2022-01-10
+
+Se corrige el XML namespace de cancelación de retenciones. Quedan de la siguiente forma:
+
+- CFDI Regulares: `http://cancelacfd.sat.gob.mx`.
+- CFDI Retenciones: `http://www.sat.gob.mx/esquemas/retencionpago/1`.
+
 ### Versión 2.0.0 2022-01-08
 
 - Se actualiza al nuevo esquema de datos de cancelación del SAT, ahora no se pide un arreglo de UUID,
-  se pide un objeto `CancelDocuments`. Se crean diferentes objetos de valor relacionados a los nuevos campos.
+  se pide un objeto `CancelDocuments`. Se crean diferentes objetos de valor relacionados con los nuevos campos.
 - Se cambia el namespace `PhpCfdi\XmlCancelacion\Definitions` a `PhpCfdi\XmlCancelacion\Models`.
 - Actualización de licencia, feliz 2022.
 

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -75,8 +75,8 @@ class Cancellation implements Countable, CapsuleInterface
     /** @noinspection PhpUnhandledExceptionInspection */
     public function exportToDocument(): DOMDocument
     {
-        $document = (new BaseDocumentBuilder())->createBaseDocument('Cancelacion', $this->documentType->value());
-
+        $builder = new BaseDocumentBuilder();
+        $document = $builder->createBaseDocument('Cancelacion', $this->documentType->xmlNamespaceCancellation());
         $cancelacion = $this->xmlDocumentElement($document);
         $cancelacion->setAttribute('RfcEmisor', $this->rfc()); // en el anexo 20 es opcional!
         $cancelacion->setAttribute('Fecha', $this->date()->format('Y-m-d\TH:i:s'));

--- a/src/Models/DocumentType.php
+++ b/src/Models/DocumentType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\XmlCancelacion\Models;
 
 use Eclipxe\Enum\Enum;
+use LogicException;
 
 /**
  * Define the document type (cfdi or retention)
@@ -23,5 +24,16 @@ final class DocumentType extends Enum
             'cfdi' => 'http://cancelacfd.sat.gob.mx',
             'retention' => 'http://cancelaretencion.sat.gob.mx',
         ];
+    }
+
+    public function xmlNamespaceCancellation(): string
+    {
+        if ($this->isCfdi()) {
+            return 'http://cancelacfd.sat.gob.mx';
+        }
+        if ($this->isRetention()) {
+            return 'http://www.sat.gob.mx/esquemas/retencionpago/1';
+        }
+        throw new LogicException('There is no xml namespace for the DocumentType'); // @codeCoverageIgnore
     }
 }

--- a/tests/Unit/Models/DocumentTypeTest.php
+++ b/tests/Unit/Models/DocumentTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\XmlCancelacion\Tests\Unit\Models;
+
+use PhpCfdi\XmlCancelacion\Models\DocumentType;
+use PhpCfdi\XmlCancelacion\Tests\TestCase;
+
+final class DocumentTypeTest extends TestCase
+{
+    public function providerXmlNamespaceCancellation(): array
+    {
+        return [
+            'cfdi' => [DocumentType::cfdi(), 'http://cancelacfd.sat.gob.mx'],
+            'retention' => [DocumentType::retention(), 'http://www.sat.gob.mx/esquemas/retencionpago/1'],
+        ];
+    }
+
+    /** @dataProvider providerXmlNamespaceCancellation */
+    public function testXmlNamespaceCancellation(DocumentType $documentType, string $expectedXmlNamespace): void
+    {
+        $this->assertSame($expectedXmlNamespace, $documentType->xmlNamespaceCancellation());
+    }
+}

--- a/tests/Unit/Models/DocumentTypeTest.php
+++ b/tests/Unit/Models/DocumentTypeTest.php
@@ -9,6 +9,7 @@ use PhpCfdi\XmlCancelacion\Tests\TestCase;
 
 final class DocumentTypeTest extends TestCase
 {
+    /** @return array<string, array{DocumentType, string}> */
     public function providerXmlNamespaceCancellation(): array
     {
         return [

--- a/tests/_files/cancellation-retention-document.xml
+++ b/tests/_files/cancellation-retention-document.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Cancelacion xmlns="http://cancelaretencion.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="LAN7008173R5" Fecha="2022-01-13T14:15:16">
+<Cancelacion xmlns="http://www.sat.gob.mx/esquemas/retencionpago/1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="LAN7008173R5" Fecha="2022-01-13T14:15:16">
   <Folios>
     <Folio UUID="11111111-2222-3333-4444-000000000001" Motivo="01" FolioSustitucion="00000000-0000-0000-0000-000000000001"/>
     <Folio UUID="11111111-2222-3333-4444-000000000002" Motivo="02" FolioSustitucion=""/>


### PR DESCRIPTION
Liberar como la versión 2.0.1

Según la documentación de los XSD del SAT para elaborar la solicitud de cancelación de comprobantes firmada se debería utilizar para CFDI de retenciones: `http://www.sat.gob.mx/esquemas/retencionpago/1`. Este PR corrige esta situación.

Además, como nota. Lo mismo debería suceder para cancelar CFDI Regulares y usar `http://www.sat.gob.mx/sitio_internet/cfd`, sin embargo, el SAT en producción sigue utilizando el XML Namespace de 2021 `http://cancelacfd.sat.gob.mx`.