### PR TITLE
Corregir problemas encontrados en SonarCloud (mantenimiento 2024-01-22)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 - Se actualiza el año de la licencia.
 - Se corrige el archivo de configuración de `php-cs-fixer`.
-- Se corrige el código para solventar los problemas de `php-cs-fixer` y `psalm`.
+- Se corrige el código para solventar los problemas de `php-cs-fixer`, `psalm` y SonarCloud.
   No produjo cambios que requieran liberar una nueva versión.
 - Se corrige el ancla del proyecto en el archivo `CONTRIBUTING.md`.
 - Se corrige la insignia de construcción del proyecto en el archivo `README.md`.

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -98,6 +98,6 @@ class Cancellation implements Countable, CapsuleInterface
 
     public function belongsToRfc(string $rfc): bool
     {
-        return ($rfc === $this->rfc());
+        return $rfc === $this->rfc();
     }
 }

--- a/src/Capsules/CancellationAnswer.php
+++ b/src/Capsules/CancellationAnswer.php
@@ -92,6 +92,6 @@ class CancellationAnswer implements CapsuleInterface
 
     public function belongsToRfc(string $rfc): bool
     {
-        return ($rfc === $this->rfc());
+        return $rfc === $this->rfc();
     }
 }

--- a/src/Capsules/ObtainRelated.php
+++ b/src/Capsules/ObtainRelated.php
@@ -69,6 +69,6 @@ class ObtainRelated implements CapsuleInterface
 
     public function belongsToRfc(string $rfc): bool
     {
-        return ($rfc === $this->rfc());
+        return $rfc === $this->rfc();
     }
 }

--- a/src/XmlCancelacionHelper.php
+++ b/src/XmlCancelacionHelper.php
@@ -40,7 +40,7 @@ class XmlCancelacionHelper
 
     public function hasCredentials(): bool
     {
-        return (null !== $this->credentials);
+        return null !== $this->credentials;
     }
 
     public function getCredentials(): Credentials

--- a/tests/Unit/Capsules/FakeCapsule.php
+++ b/tests/Unit/Capsules/FakeCapsule.php
@@ -30,6 +30,6 @@ final class FakeCapsule implements CapsuleInterface
 
     public function belongsToRfc(string $rfc): bool
     {
-        return ($rfc === $this->rfc());
+        return $rfc === $this->rfc();
     }
 }

--- a/tests/Unit/Models/CancelReasonTest.php
+++ b/tests/Unit/Models/CancelReasonTest.php
@@ -21,10 +21,10 @@ final class CancelReasonTest extends TestCase
     }
 
     /** @dataProvider providerEntries */
-    public function testEntries(CancelReason $entry, int $index, string $value): void
+    public function testEntries(CancelReason $entry, int $expectedIndex, string $expectedValue): void
     {
-        $this->assertSame($entry->index(), $index);
-        $this->assertSame($entry->value(), $value);
+        $this->assertSame($expectedIndex, $entry->index());
+        $this->assertSame($expectedValue, $entry->value());
     }
 
     /** @dataProvider providerEntries */


### PR DESCRIPTION
Se corrige el estilo de código para solventar los problemas encontrados en [SonarCloud](https://sonarcloud.io/project/issues?resolved=false&id=phpcfdi_xml-cancelacion)

- Se eliminan paréntesis innecesarios.
- Se ponen correctamente los valores esperados y comparados en un test.