### PR TITLE
Compatibilidad con PHP 8.4 (versión 2.0.3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -84,7 +84,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2, psalm
         env:
@@ -133,3 +133,31 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
+
+  infection:
+    name: Mutation testing analysis
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: xdebug
+          tools: composer:v2, infection
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Create code coverage
+        run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+      - name: infection
+        run: infection --skip-initial-tests --coverage=build/coverage --no-progress --no-interaction --logger-github

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,4 @@
-name: coverage
+name: sonarcloud
 on:
   workflow_dispatch:
   push:
@@ -6,12 +6,12 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
-# sonarsource/sonarcloud-github-action@master https://github.com/marketplace/actions/sonarcloud-scan
+# SonarSource/sonarqube-scan-action@v5 https://github.com/marketplace/actions/official-sonarqube-scan
 
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.3 (code coverage)
+    name: Create code coverage
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -30,52 +30,19 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Create code coverage
-        run: vendor/bin/phpunit --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+        run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
         uses: actions/upload-artifact@v4
+        if: ${{ !env.ACT }} # do not run using nektos/act
         with:
           name: code-coverage
           path: build/coverage
-
-  infection:
-    name: Mutation testing analysis
-    needs: tests-coverage
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          coverage: none
-          tools: composer:v2, infection
-        env:
-          fail-fast: true
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-      - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: Obtain code coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage
-          path: build/coverage
-      - name: infection
-        run: infection --skip-initial-tests --coverage=build/coverage --no-progress --no-interaction --logger-github
 
   sonarcloud-secrets:
     name: SonarCloud check secrets are present
@@ -113,7 +80,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory
@@ -122,9 +89,9 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-composer-"
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
@@ -137,7 +104,6 @@ jobs:
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/junit.xml > build/sonar-junit.xml
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/clover.xml > build/sonar-coverage.xml
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.48.0" installed="3.48.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.8.1" installed="3.8.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.8.1" installed="3.8.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.56" installed="1.10.56" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.20.0" installed="5.20.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.26.21" installed="0.26.21" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.75.0" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.13.0" installed="3.13.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.13.0" installed="3.13.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.17" installed="2.1.17" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.26.1" installed="5.26.1" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2025 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ Esta librería se mantendrá compatible con al menos la versión con
 También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes
 usar esta librería sin temor a romper tu aplicación.
 
+| xml-cancelacion | Supported PHP Versions            | Release date |
+|-----------------|-----------------------------------|--------------|
+| 1.0.0           | 7.2, 7.3, 7.4                     | 2029-10-02   |
+| 1.1.2           | 7.3, 7.4, 8.0                     | 2021-09-03   |
+| 2.0.2           | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3      | 2022-12-15   |
+| 2.0.3           | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 | 2025-06-01   |
+
 ## Contribuciones
 
 Las contribuciones con bienvenidas. Por favor, revisa [CONTRIBUTING][] para más detalles

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,22 @@
 
 Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta librería sin temor a romper tu aplicación.
 
-## Cambios no liberados en una versión
+## Listado de cambios
 
-Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
-versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
+Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de versión,
+aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
+
+### Versión 2.0.3 2025-06-01
+
+- Se hacen las modificaciones para la compatibilidad con PHP 8.4.
+- Se actualiza el año de la licencia.
+- Se actualizan los flujos de trabajo de GitHub:
+  - Se agrega PHP 8.4 a la matriz de prebas en el trabajo `tests`.
+  - Los trabajos se ejecutan en PHP 8.4, excepto `php-cs-fixer`.
+  - Se cambia el trabajo `infection` del flujo `coverage` a `build`.
+  - Se cambia el flujo `coverage` a `sonarcloud`.
+  - Se usa la nueva acción `SonarSource/sonarqube-scan-action@v5` en lugar de `sonarsource/sonarcloud-github-action@master`.
+- Se actualizan las herramientas de desarrollo.
 
 ### Mantenimiento 2024-09-09
 
@@ -29,8 +41,6 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
   - Los trabajos se ejecutan en PHP 8.3.
   - Se permite ejecutar los trabajos manualmente.
 - Se actualizan las herramientas de desarrollo.
-
-## Listado de cambios
 
 ### Versión 2.0.2 2022-12-15
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/src/Capsules/BaseDocumentBuilder.php
+++ b/src/Capsules/BaseDocumentBuilder.php
@@ -31,7 +31,7 @@ class BaseDocumentBuilder
      *
      * @param array<string, string>|null $extraNamespaces
      */
-    public function __construct(array $extraNamespaces = null)
+    public function __construct(?array $extraNamespaces = null)
     {
         if (null === $extraNamespaces) {
             $extraNamespaces = static::defaultExtraNamespaces();

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -39,7 +39,7 @@ class Cancellation implements Countable, CapsuleInterface
         string $rfc,
         CancelDocuments $documents,
         DateTimeImmutable $date,
-        DocumentType $type = null
+        ?DocumentType $type = null
     ) {
         $this->rfc = $rfc;
         $this->date = $date;

--- a/src/Models/CancelDocuments.php
+++ b/src/Models/CancelDocuments.php
@@ -19,7 +19,7 @@ final class CancelDocuments implements IteratorAggregate, Countable
     /** @var CancelDocument[] */
     private $documents;
 
-    /** @var int */
+    /** @var int<0, max> */
     private $count;
 
     public function __construct(CancelDocument ...$documents)

--- a/src/XmlCancelacionHelper.php
+++ b/src/XmlCancelacionHelper.php
@@ -167,7 +167,7 @@ class XmlCancelacionHelper
         string $uuid,
         CancelAnswer $answer,
         string $pacRfc,
-        DateTimeImmutable $dateTime = null
+        ?DateTimeImmutable $dateTime = null
     ): string {
         $rfc = $this->getCredentials()->rfc();
         $dateTime = $this->createDateTime($dateTime);

--- a/tests/Unit/Signers/CreateKeyInfoElementTraitTest.php
+++ b/tests/Unit/Signers/CreateKeyInfoElementTraitTest.php
@@ -44,7 +44,7 @@ final class CreateKeyInfoElementTraitTest extends TestCase
 
         $this->assertXmlStringEqualsXmlString(
             sprintf('<X509IssuerName>%s</X509IssuerName>', htmlspecialchars($unparsed, ENT_XML1)),
-            strval($document->saveXML($keyInfo->getElementsByTagName('X509IssuerName')[0])),
+            strval($document->saveXML($keyInfo->getElementsByTagName('X509IssuerName')->item(0))),
             'Ampersand was not correctly parsed on X509IssuerName'
         );
     }
@@ -57,7 +57,7 @@ final class CreateKeyInfoElementTraitTest extends TestCase
 
         $this->assertXmlStringEqualsXmlString(
             sprintf('<X509SerialNumber>%s</X509SerialNumber>', htmlspecialchars($unparsed, ENT_XML1)),
-            strval($document->saveXML($keyInfo->getElementsByTagName('X509SerialNumber')[0])),
+            strval($document->saveXML($keyInfo->getElementsByTagName('X509SerialNumber')->item(0))),
             'Ampersand was not correctly parsed on X509SerialNumber'
         );
     }
@@ -70,7 +70,7 @@ final class CreateKeyInfoElementTraitTest extends TestCase
 
         $this->assertXmlStringEqualsXmlString(
             sprintf('<X509Certificate>%s</X509Certificate>', htmlspecialchars($unparsed, ENT_XML1)),
-            strval($document->saveXML($keyInfo->getElementsByTagName('X509Certificate')[0])),
+            strval($document->saveXML($keyInfo->getElementsByTagName('X509Certificate')->item(0))),
             'Ampersand was not correctly parsed on X509Certificate'
         );
     }


### PR DESCRIPTION
- Se hacen las modificaciones para la compatibilidad con PHP 8.4.
- Se actualiza el año de la licencia.
- Se actualizan los flujos de trabajo de GitHub:
  - Se agrega PHP 8.4 a la matriz de prebas en el trabajo `tests`.
  - Los trabajos se ejecutan en PHP 8.4, excepto `php-cs-fixer`.
  - Se cambia el trabajo `infection` del flujo `coverage` a `build`.
  - Se cambia el flujo `coverage` a `sonarcloud`.
  - Se usa la nueva acción `SonarSource/sonarqube-scan-action@v5` en lugar de `sonarsource/sonarcloud-github-action@master`.
- Se actualizan las herramientas de desarrollo.