### PR TITLE
Eliminar compatibilidad con PHP < 8.1 (versión 2.0.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)
-        run: vendor/bin/phpunit --testdox --verbose
+        run: vendor/bin/phpunit --testdox --display-all-issues
 
   infection:
     name: Mutation testing analysis
@@ -130,6 +130,6 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Create code coverage
-        run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+        run: vendor/bin/phpunit --testdox --display-all-issues --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: infection
         run: infection --skip-initial-tests --coverage=build/coverage --no-progress --no-interaction --logger-github

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,15 +15,16 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PHP81Migration' => true,
+        '@PHP80Migration:risky' => true,
         // symfony
+        'array_indentation' => true,
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'type_declaration_spaces' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'parameters']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -37,6 +38,7 @@ return (new PhpCsFixer\Config())
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
         'fully_qualified_strict_types' => true,
+        'global_namespace_import' => ['import_classes' => true],
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/README.md
+++ b/README.md
@@ -243,12 +243,13 @@ Esta librería se mantendrá compatible con al menos la versión con
 También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes
 usar esta librería sin temor a romper tu aplicación.
 
-| xml-cancelacion | Supported PHP Versions            | Release date |
-|-----------------|-----------------------------------|--------------|
-| 1.0.0           | 7.2, 7.3, 7.4                     | 2029-10-02   |
-| 1.1.2           | 7.3, 7.4, 8.0                     | 2021-09-03   |
-| 2.0.2           | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3      | 2022-12-15   |
-| 2.0.3           | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 | 2025-06-01   |
+| xml-cancelacion | Versiones de PHP Soportadas       | Desde      |
+|-----------------|-----------------------------------|------------|
+| 1.0.0           | 7.2, 7.3, 7.4                     | 2029-10-02 |
+| 1.1.2           | 7.3, 7.4, 8.0                     | 2021-09-03 |
+| 2.0.2           | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3      | 2022-12-15 |
+| 2.0.3           | 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 | 2025-06-01 |
+| 2.0.4           | 8.1, 8.2, 8.3, 8.4                | 2025-06-01 |
 
 ## Contribuciones
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "robrichards/xmlseclibs": "^3.1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^10.5.46"
     },
     "suggest": {
         "robrichards/xmlseclibs": "Create document signatures (partially) using xmlseclibs"
@@ -57,12 +57,12 @@
         ],
         "dev:test": [
             "@dev:check-style",
-            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpunit --testdox --display-all-issues --stop-on-failure",
             "@php tools/phpstan analyse --no-progress",
             "@php tools/infection --no-progress --no-interaction --show-mutations"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": "^8.1",
         "ext-dom": "*",
         "ext-openssl": "*",
         "eclipxe/enum": "^0.2",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de versión,
 aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
 
+### Versión 2.0.4 2025-06-01
+
+- Se elimina la compatibilidad con versiones menores a PHP 8.1.
+- Se actualiza PHPUnit a la rama 10.
+
 ### Versión 2.0.3 2025-06-01
 
 - Se hacen las modificaciones para la compatibilidad con PHP 8.4.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-12 based) coding standard.</description>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    cacheResultFile="build/phpunit.result.cache"
+    cacheDirectory="build/phpunit.cache"
     bootstrap="tests/bootstrap.php"
     colors="true"
     >
@@ -10,9 +10,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
-            <directory suffix=".php">./src/</directory>
+            <directory>src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>

--- a/src/Capsules/BaseDocumentBuilder.php
+++ b/src/Capsules/BaseDocumentBuilder.php
@@ -21,7 +21,7 @@ class BaseDocumentBuilder
     private const XMLDOC_NO_FORMAT_OUTPUT = false;
 
     /** @var array<string, string> */
-    private $extraNamespaces;
+    private readonly array $extraNamespaces;
 
     /**
      * CapsuleSigner constructor.

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -15,35 +15,19 @@ class Cancellation implements Countable, CapsuleInterface
 {
     use XmlHelperFunctions;
 
-    /** @var string */
-    private $rfc;
-
-    /** @var DateTimeImmutable */
-    private $date;
-
-    /** @var CancelDocuments */
-    private $documents;
-
-    /** @var DocumentType */
-    private $documentType;
+    private DocumentType $documentType;
 
     /**
      * DTO for cancellation request, it supports CFDI and Retention
      *
-     * @param string $rfc
-     * @param CancelDocuments $documents
-     * @param DateTimeImmutable $date
      * @param DocumentType|null $type Uses CFDI if non provided
      */
     public function __construct(
-        string $rfc,
-        CancelDocuments $documents,
-        DateTimeImmutable $date,
+        private readonly string $rfc,
+        private readonly CancelDocuments $documents,
+        private readonly DateTimeImmutable $date,
         ?DocumentType $type = null
     ) {
-        $this->rfc = $rfc;
-        $this->date = $date;
-        $this->documents = $documents;
         $this->documentType = $type ?? DocumentType::cfdi();
     }
 

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -26,7 +26,7 @@ class Cancellation implements Countable, CapsuleInterface
         private readonly string $rfc,
         private readonly CancelDocuments $documents,
         private readonly DateTimeImmutable $date,
-        ?DocumentType $type = null
+        ?DocumentType $type = null,
     ) {
         $this->documentType = $type ?? DocumentType::cfdi();
     }

--- a/src/Capsules/CancellationAnswer.php
+++ b/src/Capsules/CancellationAnswer.php
@@ -14,33 +14,13 @@ class CancellationAnswer implements CapsuleInterface
 {
     use XmlHelperFunctions;
 
-    /** @var string */
-    private $uuid;
-
-    /** @var CancelAnswer */
-    private $answer;
-
-    /** @var string */
-    private $rfc;
-
-    /** @var DateTimeImmutable */
-    private $dateTime;
-
-    /** @var string */
-    private $pacRfc;
-
     public function __construct(
-        string $rfc,
-        string $uuid,
-        CancelAnswer $answer,
-        string $pacRfc,
-        DateTimeImmutable $dateTime
+        private readonly string $rfc,
+        private readonly string $uuid,
+        private readonly CancelAnswer $answer,
+        private readonly string $pacRfc,
+        private readonly DateTimeImmutable $dateTime
     ) {
-        $this->rfc = $rfc;
-        $this->uuid = $uuid;
-        $this->answer = $answer;
-        $this->dateTime = $dateTime;
-        $this->pacRfc = $pacRfc;
     }
 
     public function rfc(): string

--- a/src/Capsules/CancellationAnswer.php
+++ b/src/Capsules/CancellationAnswer.php
@@ -19,7 +19,7 @@ class CancellationAnswer implements CapsuleInterface
         private readonly string $uuid,
         private readonly CancelAnswer $answer,
         private readonly string $pacRfc,
-        private readonly DateTimeImmutable $dateTime
+        private readonly DateTimeImmutable $dateTime,
     ) {
     }
 

--- a/src/Capsules/ObtainRelated.php
+++ b/src/Capsules/ObtainRelated.php
@@ -13,24 +13,12 @@ class ObtainRelated implements CapsuleInterface
 {
     use XmlHelperFunctions;
 
-    /** @var string */
-    private $uuid;
-
-    /** @var string */
-    private $rfc;
-
-    /** @var RfcRole */
-    private $role;
-
-    /** @var string */
-    private $pacRfc;
-
-    public function __construct(string $uuid, string $rfc, RfcRole $role, string $pacRfc)
-    {
-        $this->uuid = $uuid;
-        $this->rfc = $rfc;
-        $this->role = $role;
-        $this->pacRfc = $pacRfc;
+    public function __construct(
+        private readonly string $uuid,
+        private readonly string $rfc,
+        private readonly RfcRole $role,
+        private readonly string $pacRfc
+    ) {
     }
 
     public function uuid(): string

--- a/src/Capsules/ObtainRelated.php
+++ b/src/Capsules/ObtainRelated.php
@@ -17,7 +17,7 @@ class ObtainRelated implements CapsuleInterface
         private readonly string $uuid,
         private readonly string $rfc,
         private readonly RfcRole $role,
-        private readonly string $pacRfc
+        private readonly string $pacRfc,
     ) {
     }
 

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -11,23 +11,13 @@ use Throwable;
 
 class Credentials
 {
-    /** @var string */
-    private $certificate;
+    private ?Credential $csd = null;
 
-    /** @var string */
-    private $privateKey;
-
-    /** @var string */
-    private $passPhrase;
-
-    /** @var Credential|null */
-    private $csd;
-
-    public function __construct(string $certificate, string $privateKey, string $passPhrase)
-    {
-        $this->certificate = $certificate;
-        $this->privateKey = $privateKey;
-        $this->passPhrase = $passPhrase;
+    public function __construct(
+        private readonly string $certificate,
+        private readonly string $privateKey,
+        private readonly string $passPhrase
+    ) {
     }
 
     public static function createWithPhpCfdiCredential(Credential $credential): self
@@ -83,10 +73,7 @@ class Credentials
         return $this->getCsd()->rfc();
     }
 
-    /**
-     * @return Credential
-     * @throws CannotLoadCertificateAndPrivateKey
-     */
+    /** @throws CannotLoadCertificateAndPrivateKey */
     protected function makePhpCfdiCredential(): Credential
     {
         try {
@@ -111,10 +98,7 @@ class Credentials
         return $this->csd;
     }
 
-    /**
-     * @param Credential $credential
-     * @throws CertificateIsNotCSD
-     */
+    /** @throws CertificateIsNotCSD */
     protected function setCsd(Credential $credential): void
     {
         if (! $credential->isCsd()) {

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -16,7 +16,7 @@ class Credentials
     public function __construct(
         private readonly string $certificate,
         private readonly string $privateKey,
-        private readonly string $passPhrase
+        private readonly string $passPhrase,
     ) {
     }
 

--- a/src/Exceptions/CannotLoadCertificateAndPrivateKey.php
+++ b/src/Exceptions/CannotLoadCertificateAndPrivateKey.php
@@ -12,7 +12,7 @@ class CannotLoadCertificateAndPrivateKey extends XmlCancelacionRuntimeException
         private readonly string $certificateFile,
         private readonly string $privateKeyFile,
         private readonly string $passPhrase,
-        Throwable $previous
+        Throwable $previous,
     ) {
         parent::__construct('Cannot load certificate and private key', previous: $previous);
     }

--- a/src/Exceptions/CannotLoadCertificateAndPrivateKey.php
+++ b/src/Exceptions/CannotLoadCertificateAndPrivateKey.php
@@ -8,21 +8,13 @@ use Throwable;
 
 class CannotLoadCertificateAndPrivateKey extends XmlCancelacionRuntimeException
 {
-    /** @var string */
-    private $certificateFile;
-
-    /** @var string */
-    private $privateKeyFile;
-
-    /** @var string */
-    private $passPhrase;
-
-    public function __construct(string $certificate, string $privateKey, string $passPhrase, Throwable $previous)
-    {
-        parent::__construct('Cannot load certificate and private key', 0, $previous);
-        $this->certificateFile = $certificate;
-        $this->privateKeyFile = $privateKey;
-        $this->passPhrase = $passPhrase;
+    public function __construct(
+        private readonly string $certificateFile,
+        private readonly string $privateKeyFile,
+        private readonly string $passPhrase,
+        Throwable $previous
+    ) {
+        parent::__construct('Cannot load certificate and private key', previous: $previous);
     }
 
     public function getCertificateFile(): string

--- a/src/Exceptions/CapsuleRfcDoesnotBelongToCertificateRfc.php
+++ b/src/Exceptions/CapsuleRfcDoesnotBelongToCertificateRfc.php
@@ -8,17 +8,11 @@ use PhpCfdi\XmlCancelacion\Capsules\CapsuleInterface;
 
 class CapsuleRfcDoesnotBelongToCertificateRfc extends XmlCancelacionRuntimeException
 {
-    /** @var CapsuleInterface */
-    private $capsule;
-
-    /** @var string */
-    private $certificateRfc;
-
-    public function __construct(CapsuleInterface $capsule, string $certificateRfc)
-    {
+    public function __construct(
+        private readonly CapsuleInterface $capsule,
+        private readonly string $certificateRfc,
+    ) {
         parent::__construct('The capsule RFC does not belong to certificate RFC');
-        $this->capsule = $capsule;
-        $this->certificateRfc = $certificateRfc;
     }
 
     public function getCapsule(): CapsuleInterface

--- a/src/Exceptions/CertificateIsNotCSD.php
+++ b/src/Exceptions/CertificateIsNotCSD.php
@@ -6,13 +6,9 @@ namespace PhpCfdi\XmlCancelacion\Exceptions;
 
 class CertificateIsNotCSD extends XmlCancelacionRuntimeException
 {
-    /** @var string */
-    private $serialNumber;
-
-    public function __construct(string $serialNumber)
+    public function __construct(private readonly string $serialNumber)
     {
-        parent::__construct(sprintf('The certificate [%s] is not a CSD', $serialNumber));
-        $this->serialNumber = $serialNumber;
+        parent::__construct(sprintf('The certificate [%s] is not a CSD', $this->serialNumber));
     }
 
     public function getSerialNumber(): string

--- a/src/Internal/XmlHelperFunctions.php
+++ b/src/Internal/XmlHelperFunctions.php
@@ -14,8 +14,6 @@ trait XmlHelperFunctions
     /**
      * Get the document's root element. Throw an exception if not exists.
      *
-     * @param DOMDocument $document
-     * @return DOMElement
      * @throws DocumentWithoutRootElement
      */
     private function xmlDocumentElement(DOMDocument $document): DOMElement

--- a/src/Models/CancelDocument.php
+++ b/src/Models/CancelDocument.php
@@ -11,20 +11,11 @@ use LogicException;
  */
 final class CancelDocument
 {
-    /** @var Uuid */
-    private $uuid;
-
-    /** @var CancelReason */
-    private $reason;
-
-    /** @var Uuid|null */
-    private $substituteOf;
-
-    public function __construct(Uuid $uuid, CancelReason $reason, ?Uuid $substituteOf)
-    {
-        $this->uuid = $uuid;
-        $this->reason = $reason;
-        $this->substituteOf = $substituteOf;
+    public function __construct(
+        private readonly Uuid $uuid,
+        private readonly CancelReason $reason,
+        private readonly ?Uuid $substituteOf
+    ) {
     }
 
     public static function newWithErrorsRelated(string $uuid, string $substituteOf): self

--- a/src/Models/CancelDocument.php
+++ b/src/Models/CancelDocument.php
@@ -14,7 +14,7 @@ final class CancelDocument
     public function __construct(
         private readonly Uuid $uuid,
         private readonly CancelReason $reason,
-        private readonly ?Uuid $substituteOf
+        private readonly ?Uuid $substituteOf,
     ) {
     }
 

--- a/src/Models/CancelDocuments.php
+++ b/src/Models/CancelDocuments.php
@@ -16,15 +16,15 @@ use Traversable;
  */
 final class CancelDocuments implements IteratorAggregate, Countable
 {
-    /** @var CancelDocument[] */
-    private $documents;
+    /** @var list<CancelDocument> */
+    private readonly array $documents;
 
     /** @var int<0, max> */
-    private $count;
+    private readonly int $count;
 
     public function __construct(CancelDocument ...$documents)
     {
-        $this->documents = $documents;
+        $this->documents = array_values($documents);
         $this->count = count($documents);
     }
 
@@ -35,9 +35,7 @@ final class CancelDocuments implements IteratorAggregate, Countable
     public function uuids(): array
     {
         return array_map(
-            static function (CancelDocument $document): string {
-                return $document->uuid()->getValue();
-            },
+            static fn (CancelDocument $document): string => $document->uuid()->getValue(),
             $this->documents
         );
     }

--- a/src/Models/Uuid.php
+++ b/src/Models/Uuid.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\XmlCancelacion\Models;
 
 use InvalidArgumentException;
+use Stringable;
 
 /**
  * Value object of a CFDI UUID
  */
-final class Uuid
+final class Uuid implements Stringable
 {
-    /** @var string */
-    private $value;
+    private string $value;
 
     public function __construct(string $value)
     {

--- a/src/Signers/CreateKeyInfoElementTrait.php
+++ b/src/Signers/CreateKeyInfoElementTrait.php
@@ -9,14 +9,7 @@ use DOMElement;
 
 trait CreateKeyInfoElementTrait
 {
-    /**
-     * @param DOMDocument $document
-     * @param string $issuerName
-     * @param string $serialNumber
-     * @param string $pemContents
-     * @param array<mixed> $pubKeyData
-     * @return DOMElement
-     */
+    /** @param array<mixed> $pubKeyData */
     protected function createKeyInfoElement(
         DOMDocument $document,
         string $issuerName,
@@ -46,11 +39,7 @@ trait CreateKeyInfoElementTrait
         return $keyInfo;
     }
 
-    /**
-     * @param DOMDocument $document
-     * @param array<mixed> $pubKeyData
-     * @return DOMElement
-     */
+    /** @param array<mixed> $pubKeyData */
     private function createKeyValueElement(DOMDocument $document, array $pubKeyData): DOMElement
     {
         /** @var array{type: int, rsa: array{n: string, e: string}} $pubKeyData */

--- a/src/Signers/CreateKeyInfoElementTrait.php
+++ b/src/Signers/CreateKeyInfoElementTrait.php
@@ -15,7 +15,7 @@ trait CreateKeyInfoElementTrait
         string $issuerName,
         string $serialNumber,
         string $pemContents,
-        array $pubKeyData
+        array $pubKeyData,
     ): DOMElement {
         $x509Data = $document->createElement('X509Data');
         $x509IssuerSerial = $document->createElement('X509IssuerSerial');

--- a/src/Signers/DOMSigner.php
+++ b/src/Signers/DOMSigner.php
@@ -27,17 +27,13 @@ class DOMSigner implements SignerInterface
 
     private const SHA1_BINARY = true;
 
-    /** @var string */
-    private $digestSource = '';
+    private string $digestSource = '';
 
-    /** @var string */
-    private $digestValue = '';
+    private string $digestValue = '';
 
-    /** @var string */
-    private $signedInfoSource = '';
+    private string $signedInfoSource = '';
 
-    /** @var string */
-    private $signedInfoValue = '';
+    private string $signedInfoValue = '';
 
     public function getDigestSource(): string
     {

--- a/src/Signers/SignerInterface.php
+++ b/src/Signers/SignerInterface.php
@@ -18,18 +18,12 @@ interface SignerInterface
     /**
      * Sign de capsule and return the generated XML
      *
-     * @param CapsuleInterface $capsule
-     * @param Credentials $credentials
-     * @return string
      * @throws CapsuleRfcDoesnotBelongToCertificateRfc
      */
     public function signCapsule(CapsuleInterface $capsule, Credentials $credentials): string;
 
     /**
      * Sign the DOMDocument with the specified credentials
-     *
-     * @param DOMDocument $document
-     * @param Credentials $credentials
      */
     public function signDocument(DOMDocument $document, Credentials $credentials): void;
 }

--- a/src/Signers/XmlSecLibsSigner.php
+++ b/src/Signers/XmlSecLibsSigner.php
@@ -27,7 +27,7 @@ class XmlSecLibsSigner implements SignerInterface
             // move XmlSecLibs signature to internal method
             $sigNode = $this->signDocumentInternal($document, $credentials);
         } catch (Exception $xmlSecLibsException) {
-            throw new LogicException('Cannot create signature using XmlSecLibs', 0, $xmlSecLibsException);
+            throw new LogicException('Cannot create signature using XmlSecLibs', previous: $xmlSecLibsException);
         }
 
         // create the KeyInfo element using own procedure
@@ -44,8 +44,6 @@ class XmlSecLibsSigner implements SignerInterface
     }
 
     /**
-     * @param DOMDocument $document
-     * @param Credentials $credentials
      * @return DOMElement Signature node
      * @throws Exception
      */

--- a/src/XmlCancelacionHelper.php
+++ b/src/XmlCancelacionHelper.php
@@ -110,7 +110,7 @@ class XmlCancelacionHelper
      */
     public function signRetentionCancellationUuids(
         CancelDocuments $documents,
-        ?DateTimeImmutable $dateTime = null
+        ?DateTimeImmutable $dateTime = null,
     ): string {
         $capsule = $this->createCancellationObject($documents, $dateTime, DocumentType::retention());
         return $this->signCapsule($capsule);
@@ -132,7 +132,7 @@ class XmlCancelacionHelper
         string $uuid,
         CancelAnswer $answer,
         string $pacRfc,
-        ?DateTimeImmutable $dateTime = null
+        ?DateTimeImmutable $dateTime = null,
     ): string {
         $rfc = $this->getCredentials()->rfc();
         $dateTime = $this->createDateTime($dateTime);
@@ -155,7 +155,7 @@ class XmlCancelacionHelper
     protected function createCancellationObject(
         CancelDocuments $documents,
         ?DateTimeImmutable $dateTime,
-        DocumentType $type
+        DocumentType $type,
     ): Cancellation {
         return new Cancellation($this->getCredentials()->rfc(), $documents, $this->createDateTime($dateTime), $type);
     }

--- a/src/XmlCancelacionHelper.php
+++ b/src/XmlCancelacionHelper.php
@@ -20,21 +20,13 @@ use PhpCfdi\XmlCancelacion\Signers\SignerInterface;
 
 class XmlCancelacionHelper
 {
-    /** @var Credentials|null */
-    private $credentials;
-
-    /** @var SignerInterface */
-    private $signer;
+    private SignerInterface $signer;
 
     /**
      * Helper object to create xml signed documents ready to send to PAC/SAT
-     *
-     * @param Credentials|null $credentials
-     * @param SignerInterface|null $signer
      */
-    public function __construct(?Credentials $credentials = null, ?SignerInterface $signer = null)
+    public function __construct(private ?Credentials $credentials = null, ?SignerInterface $signer = null)
     {
-        $this->credentials = $credentials;
         $this->signer = $signer ?? new DOMSigner();
     }
 
@@ -84,10 +76,6 @@ class XmlCancelacionHelper
 
     /**
      * Creates an XML Signed cancellation request for a single CFDI
-     *
-     * @param CancelDocument $document
-     * @param DateTimeImmutable|null $dateTime
-     * @return string
      */
     public function signCancellation(CancelDocument $document, ?DateTimeImmutable $dateTime = null): string
     {
@@ -98,10 +86,6 @@ class XmlCancelacionHelper
     /**
      * Creates an XML Signed cancellation request for one or multiple CFDI
      * Is adviced to always send a request for only 1 UUID
-     *
-     * @param CancelDocuments $documents
-     * @param DateTimeImmutable|null $dateTime
-     * @return string
      */
     public function signCancellationUuids(CancelDocuments $documents, ?DateTimeImmutable $dateTime = null): string
     {
@@ -112,10 +96,6 @@ class XmlCancelacionHelper
     /**
      * Creates an XML Signed cancellation request for a single Retention
      * Is adviced to always send a request for only 1 UUID
-     *
-     * @param CancelDocument $document
-     * @param DateTimeImmutable|null $dateTime
-     * @return string
      */
     public function signRetentionCancellation(CancelDocument $document, ?DateTimeImmutable $dateTime = null): string
     {
@@ -127,10 +107,6 @@ class XmlCancelacionHelper
     /**
      * Creates an XML Signed cancellation request for one or multiple Retention
      * Is adviced to always send a request for only 1 UUID
-     *
-     * @param CancelDocuments $documents
-     * @param DateTimeImmutable|null $dateTime
-     * @return string
      */
     public function signRetentionCancellationUuids(
         CancelDocuments $documents,
@@ -142,11 +118,6 @@ class XmlCancelacionHelper
 
     /**
      * Creates an XML Signed request to obtain the related CFDI documents to a single UUID
-     *
-     * @param string $uuid
-     * @param RfcRole $role
-     * @param string $pacRfc
-     * @return string
      */
     public function signObtainRelated(string $uuid, RfcRole $role, string $pacRfc): string
     {
@@ -156,12 +127,6 @@ class XmlCancelacionHelper
 
     /**
      * Creates an XML Signed cancellation answer (to accept or reject a cancellation)
-
-     * @param string $uuid
-     * @param CancelAnswer $answer
-     * @param string $pacRfc
-     * @param DateTimeImmutable|null $dateTime
-     * @return string
      */
     public function signCancellationAnswer(
         string $uuid,
@@ -185,10 +150,6 @@ class XmlCancelacionHelper
      * This method was isolated to be able to test the calls made by specific methods
      * It is not intended to be replaced or overrided by anything but tests
      *
-     * @param CancelDocuments $documents
-     * @param DateTimeImmutable|null $dateTime
-     * @param DocumentType $type
-     * @return Cancellation
      * @internal
      */
     protected function createCancellationObject(

--- a/tests/System/XmlSignedUsingDOMSignerTest.php
+++ b/tests/System/XmlSignedUsingDOMSignerTest.php
@@ -14,8 +14,7 @@ use PhpCfdi\XmlCancelacion\Tests\TestCase;
 
 final class XmlSignedUsingDOMSignerTest extends TestCase
 {
-    /** @var DOMSigner */
-    private $domSigner;
+    private DOMSigner $domSigner;
 
     public function setUp(): void
     {

--- a/tests/Unit/Capsules/BaseDocumentBuilderTest.php
+++ b/tests/Unit/Capsules/BaseDocumentBuilderTest.php
@@ -6,8 +6,9 @@ namespace PhpCfdi\XmlCancelacion\Tests\Unit\Capsules;
 
 use PhpCfdi\XmlCancelacion\Capsules\BaseDocumentBuilder;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/** @covers \PhpCfdi\XmlCancelacion\Capsules\BaseDocumentBuilder */
+#[CoversClass(BaseDocumentBuilder::class)]
 final class BaseDocumentBuilderTest extends TestCase
 {
     public function testDefaultNameSpacesExactContentAndOrder(): void

--- a/tests/Unit/Capsules/FakeCapsule.php
+++ b/tests/Unit/Capsules/FakeCapsule.php
@@ -10,12 +10,8 @@ use PhpCfdi\XmlCancelacion\Capsules\CapsuleInterface;
 
 final class FakeCapsule implements CapsuleInterface
 {
-    /** @var string */
-    private $rfc;
-
-    public function __construct(string $rfc)
+    public function __construct(private readonly string $rfc)
     {
-        $this->rfc = $rfc;
     }
 
     public function rfc(): string

--- a/tests/Unit/CredentialsTest.php
+++ b/tests/Unit/CredentialsTest.php
@@ -10,9 +10,10 @@ use PhpCfdi\XmlCancelacion\Credentials;
 use PhpCfdi\XmlCancelacion\Exceptions\CannotLoadCertificateAndPrivateKey;
 use PhpCfdi\XmlCancelacion\Exceptions\CertificateIsNotCSD;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/** @covers \PhpCfdi\XmlCancelacion\Credentials */
+#[CoversClass(Credentials::class)]
 final class CredentialsTest extends TestCase
 {
     public function testValidCredentialsProperties(): void

--- a/tests/Unit/Models/CancelDocumentsTest.php
+++ b/tests/Unit/Models/CancelDocumentsTest.php
@@ -16,6 +16,22 @@ final class CancelDocumentsTest extends TestCase
         $this->assertCount(0, $documents);
     }
 
+    public function testCreateWithArrayKeys(): void
+    {
+        $documentsArray = [
+            'first' => CancelDocument::newNotExecuted('12345678-2222-3333-4444-1234567890DD'),
+            'second' => CancelDocument::newNormativeToGlobal('12345678-2222-3333-4444-1234567890EE'),
+        ];
+
+        $documents = new CancelDocuments(...$documentsArray);
+
+        $this->assertSame(
+            array_values($documentsArray),
+            iterator_to_array($documents),
+            'Iterator should return an array list'
+        );
+    }
+
     public function testCreateWithMultipleContents(): void
     {
         $documentsArray = [

--- a/tests/Unit/Models/CancelReasonTest.php
+++ b/tests/Unit/Models/CancelReasonTest.php
@@ -6,11 +6,12 @@ namespace PhpCfdi\XmlCancelacion\Tests\Unit\Models;
 
 use PhpCfdi\XmlCancelacion\Models\CancelReason;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class CancelReasonTest extends TestCase
 {
     /** @return array<string, array{CancelReason, int, string}> */
-    public function providerEntries(): array
+    public static function providerEntries(): array
     {
         return [
             'with errors related' => [CancelReason::withErrorsRelated(), 1, '01'],
@@ -20,21 +21,21 @@ final class CancelReasonTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerEntries */
+    #[DataProvider('providerEntries')]
     public function testEntries(CancelReason $entry, int $expectedIndex, string $expectedValue): void
     {
         $this->assertSame($expectedIndex, $entry->index());
         $this->assertSame($expectedValue, $entry->value());
     }
 
-    /** @dataProvider providerEntries */
+    #[DataProvider('providerEntries')]
     public function testCreatedByIndex(CancelReason $entry, int $index, string $value): void
     {
         $created = new CancelReason($index);
         $this->assertEquals($entry, $created);
     }
 
-    /** @dataProvider providerEntries */
+    #[DataProvider('providerEntries')]
     public function testCreatedByValue(CancelReason $entry, int $index, string $value): void
     {
         $created = new CancelReason($value);

--- a/tests/Unit/Models/DocumentTypeTest.php
+++ b/tests/Unit/Models/DocumentTypeTest.php
@@ -6,11 +6,12 @@ namespace PhpCfdi\XmlCancelacion\Tests\Unit\Models;
 
 use PhpCfdi\XmlCancelacion\Models\DocumentType;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class DocumentTypeTest extends TestCase
 {
     /** @return array<string, array{DocumentType, string}> */
-    public function providerXmlNamespaceCancellation(): array
+    public static function providerXmlNamespaceCancellation(): array
     {
         return [
             'cfdi' => [DocumentType::cfdi(), 'http://cancelacfd.sat.gob.mx'],
@@ -18,7 +19,7 @@ final class DocumentTypeTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerXmlNamespaceCancellation */
+    #[DataProvider('providerXmlNamespaceCancellation')]
     public function testXmlNamespaceCancellation(DocumentType $documentType, string $expectedXmlNamespace): void
     {
         $this->assertSame($expectedXmlNamespace, $documentType->xmlNamespaceCancellation());

--- a/tests/Unit/Models/UuidTest.php
+++ b/tests/Unit/Models/UuidTest.php
@@ -7,11 +7,12 @@ namespace PhpCfdi\XmlCancelacion\Tests\Unit\Models;
 use InvalidArgumentException;
 use PhpCfdi\XmlCancelacion\Models\Uuid;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class UuidTest extends TestCase
 {
     /** @return array<string, array{string}> */
-    public function providerValidateInvalidCases(): array
+    public static function providerValidateInvalidCases(): array
     {
         return [
             'incorrect length +1 start' => ['A12345678-2222-3333-4444-123456789012'],
@@ -23,7 +24,7 @@ final class UuidTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerValidateInvalidCases */
+    #[DataProvider('providerValidateInvalidCases')]
     public function testValidateInvalidCases(string $value): void
     {
         $this->assertFalse(Uuid::isValid($value));
@@ -32,7 +33,7 @@ final class UuidTest extends TestCase
     }
 
     /** @return array<string, array{string}> */
-    public function providerValidateValidCases(): array
+    public static function providerValidateValidCases(): array
     {
         return [
             'numbers' => ['12345678-2222-3333-4444-123456789012'],
@@ -41,7 +42,7 @@ final class UuidTest extends TestCase
         ];
     }
 
-    /** @dataProvider providerValidateValidCases */
+    #[DataProvider('providerValidateValidCases')]
     public function testValidateValidCases(string $value): void
     {
         $this->assertTrue(Uuid::isValid($value));

--- a/tests/Unit/Signers/XmlSecLibsSignerTest.php
+++ b/tests/Unit/Signers/XmlSecLibsSignerTest.php
@@ -14,9 +14,10 @@ use PhpCfdi\XmlCancelacion\Models\CancelDocuments;
 use PhpCfdi\XmlCancelacion\Signers\DOMSigner;
 use PhpCfdi\XmlCancelacion\Signers\XmlSecLibsSigner;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/** @covers \PhpCfdi\XmlCancelacion\Signers\XmlSecLibsSigner */
+#[CoversClass(XmlSecLibsSigner::class)]
 final class XmlSecLibsSignerTest extends TestCase
 {
     public function testsignIsEqualToDomSigner(): void

--- a/tests/Unit/XmlCancelacionHelperSpy.php
+++ b/tests/Unit/XmlCancelacionHelperSpy.php
@@ -14,11 +14,9 @@ use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
 
 final class XmlCancelacionHelperSpy extends XmlCancelacionHelper
 {
-    /** @var Cancellation */
-    private $lastCancellation;
+    private ?Cancellation $lastCancellation = null;
 
-    /** @var CapsuleInterface */
-    private $lastSignedCapsule;
+    private ?CapsuleInterface $lastSignedCapsule = null;
 
     protected function createCancellationObject(
         CancelDocuments $documents,
@@ -49,6 +47,9 @@ final class XmlCancelacionHelperSpy extends XmlCancelacionHelper
 
     public function getLastSignedCapsule(): CapsuleInterface
     {
+        if (null === $this->lastSignedCapsule) {
+            throw new LogicException('Must call a method that set a last signed capsule first');
+        }
         return $this->lastSignedCapsule;
     }
 }

--- a/tests/Unit/XmlCancelacionHelperSpy.php
+++ b/tests/Unit/XmlCancelacionHelperSpy.php
@@ -21,7 +21,7 @@ final class XmlCancelacionHelperSpy extends XmlCancelacionHelper
     protected function createCancellationObject(
         CancelDocuments $documents,
         ?DateTimeImmutable $dateTime,
-        DocumentType $type
+        DocumentType $type,
     ): Cancellation {
         $this->lastCancellation = parent::createCancellationObject(
             $documents,

--- a/tests/Unit/XmlCancelacionHelperTest.php
+++ b/tests/Unit/XmlCancelacionHelperTest.php
@@ -21,13 +21,13 @@ use PHPUnit\Framework\MockObject\MockObject;
 final class XmlCancelacionHelperTest extends TestCase
 {
     /** @return Credentials&MockObject */
-    private function createFakeCredentials()
+    private function createFakeCredentials(): Credentials
     {
         return $this->createMock(Credentials::class);
     }
 
     /** @return  SignerInterface&MockObject $fakeSigner */
-    private function createFakeSigner()
+    private function createFakeSigner(): SignerInterface
     {
         return $this->createMock(SignerInterface::class);
     }

--- a/tests/Unit/XmlCancelacionHelperTest.php
+++ b/tests/Unit/XmlCancelacionHelperTest.php
@@ -15,9 +15,10 @@ use PhpCfdi\XmlCancelacion\Signers\DOMSigner;
 use PhpCfdi\XmlCancelacion\Signers\SignerInterface;
 use PhpCfdi\XmlCancelacion\Tests\TestCase;
 use PhpCfdi\XmlCancelacion\XmlCancelacionHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 
-/** @covers \PhpCfdi\XmlCancelacion\XmlCancelacionHelper */
+#[CoversClass(XmlCancelacionHelper::class)]
 final class XmlCancelacionHelperTest extends TestCase
 {
     /** @return Credentials&MockObject */


### PR DESCRIPTION
- Se elimina la compatibilidad con versiones menores a PHP 8.1.
- Se actualiza PHPUnit a la rama 10.

Esta actividad facilita el mantenimiento de las librerías para los desarrolladores de PhpCfdi.
