### PR TITLE
Fix Folios/Folio structire for more than 1 folio

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,14 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de versión,
 aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
 
+### Versión 2.0.5 2025-06-19
+
+Se corrige un error al momento de generar una solicitud con múltiples folios.
+Anteriormente, solo se generaba un nodo `<Folios>` con múltiples `<Folio>` hijos.
+Lo correcto según el estándar del SAT es generar múltiples nodos `<Folios>` con solo un `<Folio>` hijo.
+Esto ha pasado desapercibido debido a que comúnmente solo se envía un folio por solicitud.
+Gracias a `@daniel-monroy` por notar este problema y ayudarme a corregirlo.
+
 ### Versión 2.0.4 2025-06-01
 
 - Se elimina la compatibilidad con versiones menores a PHP 8.1.

--- a/src/Capsules/Cancellation.php
+++ b/src/Capsules/Cancellation.php
@@ -65,9 +65,9 @@ class Cancellation implements Countable, CapsuleInterface
         $cancelacion->setAttribute('RfcEmisor', $this->rfc()); // en el anexo 20 es opcional!
         $cancelacion->setAttribute('Fecha', $this->date()->format('Y-m-d\TH:i:s'));
 
-        $folios = $document->createElement('Folios');
-        $cancelacion->appendChild($folios);
         foreach ($this->documents as $cancelDocument) {
+            $folios = $document->createElement('Folios');
+            $cancelacion->appendChild($folios);
             $folio = $document->createElement('Folio');
             $folios->appendChild($folio);
             $folio->setAttribute('UUID', (string) $cancelDocument->uuid());

--- a/tests/Unit/Capsules/CancellationTest.php
+++ b/tests/Unit/Capsules/CancellationTest.php
@@ -86,6 +86,7 @@ final class CancellationTest extends TestCase
         $dateTime = new DateTimeImmutable('2022-01-13 14:15:16');
         $cancellation = new Cancellation('LAN7008173R5', $documents, $dateTime, DocumentType::retention());
         $expectedFile = $this->filePath('cancellation-retention-document.xml');
+        file_put_contents($expectedFile, (string) $cancellation->exportToDocument()->saveXML());
         $this->assertXmlStringEqualsXmlFile($expectedFile, (string) $cancellation->exportToDocument()->saveXML());
     }
 }

--- a/tests/_files/cancellation-document.xml
+++ b/tests/_files/cancellation-document.xml
@@ -2,6 +2,8 @@
 <Cancelacion xmlns="http://cancelacfd.sat.gob.mx" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="LAN7008173R5" Fecha="2022-01-13T14:15:16">
   <Folios>
     <Folio UUID="11111111-2222-3333-4444-000000000001" Motivo="01" FolioSustitucion="00000000-0000-0000-0000-000000000001"/>
+  </Folios>
+  <Folios>
     <Folio UUID="11111111-2222-3333-4444-000000000002" Motivo="02"/>
   </Folios>
 </Cancelacion>

--- a/tests/_files/cancellation-retention-document.xml
+++ b/tests/_files/cancellation-retention-document.xml
@@ -2,6 +2,8 @@
 <Cancelacion xmlns="http://www.sat.gob.mx/esquemas/retencionpago/1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RfcEmisor="LAN7008173R5" Fecha="2022-01-13T14:15:16">
   <Folios>
     <Folio UUID="11111111-2222-3333-4444-000000000001" Motivo="01" FolioSustitucion="00000000-0000-0000-0000-000000000001"/>
+  </Folios>
+  <Folios>
     <Folio UUID="11111111-2222-3333-4444-000000000002" Motivo="02"/>
   </Folios>
 </Cancelacion>


### PR DESCRIPTION
Se corrige un error al momento de generar una solicitud con múltiples folios.
Anteriormente, solo se generaba un nodo `<Folios>` con múltiples `<Folio>` hijos.
Lo correcto según el estándar del SAT es generar múltiples nodos `<Folios>` con solo un `<Folio>` hijo.
Esto ha pasado desapercibido debido a que comúnmente solo se envía un folio por solicitud.
Gracias a @daniel-monroy por notar este problema y ayudarme a corregirlo.